### PR TITLE
Rename refetch to reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ And use it l.
 
 ### The Query
 
-A **query** is an abstraction for loading and caching data. It consists of a **loading function** which produces some data, and a **unique key** which identifies that data. Queries expose their reactive `data`, `error`, and `loading` state, along with a `refetch` function.
+A **query** is an abstraction for loading and caching data. It consists of a **loading function** which produces some data, and a **unique key** which identifies that data. Queries expose their reactive `data`, `error`, and `loading` state, along with a `reload` function.
 
 Svelte Tiny Query uses Svelte 5's `$state` to **cache _all_ states of _all_ queries**, indexed by their keys. When you use a query, you are essentially getting reactive access to a small part of the global cache based on the current key.
 
@@ -59,7 +59,7 @@ The key of a query has to uniquely identify the data that the query produces, an
 
 ### When is a query reloaded?
 
-Each query is loaded when it is first used (unless there exists not yet stale cache data for it) and when its `refetch` function is used.
+Each query is loaded when it is first used (unless there exists not yet stale cache data for it) and when its `reload` function is used.
 
 ## API Reference
 
@@ -79,7 +79,7 @@ Svelte Tiny Query only exports 2 functions (`createQuery` and `invalidateQueries
       error: E | undefined,
       loading: boolean
     },
-    refetch: () => void
+    reload: () => void
   }
 ```
 
@@ -138,11 +138,11 @@ options?: {
     error: E | undefined,
     loading: boolean
   },
-  refetch: () => void
+  reload: () => void
 }
 ```
 
-The `createQuery` function returns a query function that gives you access to the reactive state of the query (`data`, `error`, `loading`), and a `refetch` function.
+The `createQuery` function returns a query function that gives you access to the reactive state of the query (`data`, `error`, `loading`), and a `reload` function.
 
 - The query function checks the cache for existing data. If the data is found and not stale, it’s returned immediately.
 
@@ -150,7 +150,7 @@ The `createQuery` function returns a query function that gives you access to the
 
 - Once the loading function completes, the query state updates with the new data or error, and the data is cached for future use.
 
-- The `refetch` function can be used to manually reload the data, which will update the cache and reset the state as needed.
+- The `reload` function can be used to manually reload the data, which will update the cache and reset the state as needed.
 
 - If the query has reactive parameters, a change will trigger a re-initialization, causing a reload based on the new cache key.
 
@@ -182,7 +182,7 @@ Svelte Tiny Query deliberately omits some features that other query libraries of
 There is no need to set up a query provider. Queries and their caches are global in your app.
 
 **Timed and Window Focus Reloading**<br />
-Use `$effect`, `setInterval` (or `addEventListener`) and `refetch` to achieve this yourself.
+Use `$effect`, `setInterval` (or `addEventListener`) and `reload` to achieve this yourself.
 
 **Dependent Queries**<br />
 Use `$derived` to conditionally invoke the query function.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-tiny-query",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/Kidesia/svelte-tiny-query.git"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "0.1.1",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/Kidesia/svelte-tiny-query"
+		"url": "git+https://github.com/Kidesia/svelte-tiny-query.git"
 	},
 	"homepage": "https://github.com/Kidesia/svelte-tiny-query#readme",
 	"bugs": {
@@ -34,8 +34,8 @@
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
-			"default": "./dist/index.js",
-			"svelte": "./dist/index.js"
+			"svelte": "./dist/index.js",
+			"default": "./dist/index.js"
 		}
 	},
 	"peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-tiny-query",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/Kidesia/svelte-tiny-query.git"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,11 @@
 	"version": "0.1.0",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/sra448/svelte-simple-query.git"
+		"url": "git+https://github.com/Kidesia/svelte-tiny-query"
+	},
+	"homepage": "https://github.com/Kidesia/svelte-tiny-query#readme",
+	"bugs": {
+		"url": "https://github.com/Kidesia/svelte-tiny-query/issues"
 	},
 	"scripts": {
 		"dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-tiny-query",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/Kidesia/svelte-tiny-query"
@@ -34,7 +34,8 @@
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
-			"default": "./dist/index.js"
+			"default": "./dist/index.js",
+			"svelte": "./dist/index.js"
 		}
 	},
 	"peerDependencies": {

--- a/src/lib/svelte-tiny-query/query.svelte.ts
+++ b/src/lib/svelte-tiny-query/query.svelte.ts
@@ -54,6 +54,9 @@ const errorByKey = $state({} as Record<string, unknown>);
 const staleTimeStampByKey = $state({} as Record<string, number>);
 const activeQueriesByKey = $state([] as string[][]);
 
+/**
+ * Global loading state to track the number of active queries.
+ */
 export const globalLoading = $state({ count: 0 });
 
 // Actions
@@ -179,13 +182,16 @@ export function createQuery<E, P = void, T = unknown>(
 			};
 		});
 
-		const refetch = () => {
+		const reload = () => {
 			queriesByKey[internal.currentKey]?.();
 		};
 
 		return {
 			query,
-			refetch
+			/**
+			 * reloades the query.
+			 */
+			reload
 		};
 	};
 }

--- a/src/lib/svelte-tiny-query/query.svelte.ts
+++ b/src/lib/svelte-tiny-query/query.svelte.ts
@@ -63,13 +63,21 @@ export const globalLoading = $state({ count: 0 });
  * @param key Path of the query
  * @param loadFn Function to load the data
  * @param options Options for the query
+ * @param options.initialData Initial data to be used before the query is loaded
+ * @param options.staleTime Time in milliseconds after which the query is considered stale
  * @returns Query function to use in Svelte components
  */
 export function createQuery<E, P = void, T = unknown>(
 	key: string[] | ((queryParam: P) => string[]),
 	loadFn: (queryParam: P) => Promise<LoadResult<T, E>>,
 	options?: {
-		initialData?: T; // TODO: this should also take a function
+		/**
+		 * Initial data to be used before the query is loaded.
+		 */
+		initialData?: T; // TODO: should also take a function (param: P) => T
+		/**
+		 * Time in milliseconds after which the query is considered stale.
+		 */
 		staleTime?: number;
 	}
 ) {

--- a/src/lib/svelte-tiny-query/query.svelte.ts
+++ b/src/lib/svelte-tiny-query/query.svelte.ts
@@ -173,10 +173,10 @@ export function createQuery<E, P = void, T = unknown>(
 			return () => {
 				untrack(() => {
 					const activeQueryIndex = activeQueryKeys.findIndex(
-						(key) => key.join('__') === cacheKey
+						(key) => key?.join('__') === cacheKey
 					);
 
-					if (activeQueryIndex > -1) {
+					if (activeQueryIndex >= 0) {
 						activeQueryKeys.splice(activeQueryIndex, 1);
 					}
 				});

--- a/src/routes/MemeIdea.svelte
+++ b/src/routes/MemeIdea.svelte
@@ -30,7 +30,7 @@
 
 	const param = $state({ id: 1 });
 
-	const { query, refetch } = emojiQuery(param);
+	const { query, reload } = emojiQuery(param);
 </script>
 
 <div class="emojis-container">
@@ -39,7 +39,7 @@
 	</h1>
 
 	<div class="flex">
-		<button onclick={refetch}>↻</button>
+		<button onclick={reload}>↻</button>
 		<button onclick={() => param.id--}>-</button>
 		<button onclick={() => param.id++}>+</button>
 	</div>


### PR DESCRIPTION
It is not always necessarily about fetching data. I think `load` is more broad of a term and fits better.

Also iterates on the package.json and README a wee bit. 
