### PR TITLE
Fix Removing Queries from ActiveQueries Cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-tiny-query",
-	"version": "0.1.6",
+	"version": "0.1.7",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/Kidesia/svelte-tiny-query.git"

--- a/src/lib/svelte-tiny-query/query.svelte.ts
+++ b/src/lib/svelte-tiny-query/query.svelte.ts
@@ -179,7 +179,9 @@ export function createQuery<E, P = void, T = unknown>(
 					);
 
 					if (activeQueryIndex >= 0) {
-						activeQueries.keys.splice(activeQueryIndex, 1);
+						activeQueries.keys = activeQueries.keys.filter(
+							(_, index) => index !== activeQueryIndex
+						);
 					}
 				});
 			};

--- a/src/lib/svelte-tiny-query/query.svelte.ts
+++ b/src/lib/svelte-tiny-query/query.svelte.ts
@@ -215,6 +215,15 @@ export function invalidateQueries(
 	options?: { force?: boolean; exact?: boolean }
 ) {
 	const cacheKey = key.join('__');
+
+	// marks all relevant queries as stale
+	Object.keys(staleTimeStampByKey).forEach((key) => {
+		if (options?.exact ? key === cacheKey : key.startsWith(cacheKey)) {
+			staleTimeStampByKey[key] = +new Date() - 1;
+		}
+	});
+
+	// reloads the currently active queries right away
 	const queriesToInvalidate = activeQueries.keys.filter((query) =>
 		options?.exact
 			? query.join('__') === cacheKey


### PR DESCRIPTION
This PR iterates on the invalidateQueries feature

- Makes the activeQueries detection more save (splice did sometimes not work?)
- In addition to just re-running all matching active queries, all other matching queries also get marked as stale