### PR TITLE
Makes `loading` be true initially

### DIFF
--- a/src/lib/svelte-tiny-query/query.svelte.ts
+++ b/src/lib/svelte-tiny-query/query.svelte.ts
@@ -139,14 +139,17 @@ export function createQuery<E, P = void, T = unknown>(
 	const initializeState = (currentKey: string) => {
 		const internal = $state({ currentKey });
 		const query = $state({
-			loading: false,
+			loading: true,
 			error: undefined as E | undefined,
 			data: options?.initialData,
 			staleTimeStamp: undefined as number | undefined
 		});
 
 		$effect(() => {
-			query.loading = !!loadingByKey[internal.currentKey];
+			query.loading =
+				internal.currentKey in loadingByKey
+					? loadingByKey[internal.currentKey]
+					: true;
 		});
 
 		$effect(() => {

--- a/tests/createQuery.svelte.test.ts
+++ b/tests/createQuery.svelte.test.ts
@@ -29,12 +29,6 @@ describe('createQuery', () => {
 			{
 				data: undefined,
 				error: undefined,
-				loading: false,
-				staleTimeStamp: undefined
-			},
-			{
-				data: undefined,
-				error: undefined,
 				loading: true,
 				staleTimeStamp: undefined
 			},
@@ -74,12 +68,6 @@ describe('createQuery', () => {
 			{
 				data: 'initial data',
 				error: undefined,
-				loading: false,
-				staleTimeStamp: undefined
-			},
-			{
-				data: 'initial data',
-				error: undefined,
 				loading: true,
 				staleTimeStamp: undefined
 			},
@@ -113,12 +101,6 @@ describe('createQuery', () => {
 
 		expect(states.value).toEqual([
 			// Initial state
-			{
-				data: undefined,
-				error: undefined,
-				loading: false,
-				staleTimeStamp: undefined
-			},
 			{
 				data: undefined,
 				error: undefined,
@@ -171,12 +153,6 @@ describe('createQuery', () => {
 
 		expect(states.value).toEqual([
 			// Initial state
-			{
-				data: undefined,
-				error: undefined,
-				loading: false,
-				staleTimeStamp: undefined
-			},
 			{
 				data: undefined,
 				error: undefined,
@@ -246,12 +222,6 @@ describe('createQuery', () => {
 
 		expect(states.value).toEqual([
 			// Initial state
-			{
-				data: undefined,
-				error: undefined,
-				loading: false,
-				staleTimeStamp: undefined
-			},
 			{
 				data: undefined,
 				error: undefined,
@@ -348,12 +318,6 @@ describe('createQuery', () => {
 
 		expect(states.value).toEqual([
 			// Initial state
-			{
-				data: undefined,
-				error: undefined,
-				loading: false,
-				staleTimeStamp: undefined
-			},
 			{
 				data: undefined,
 				error: undefined,
@@ -462,12 +426,6 @@ describe('createQuery', () => {
 			{
 				data: undefined,
 				error: undefined,
-				loading: false,
-				staleTimeStamp: undefined
-			},
-			{
-				data: undefined,
-				error: undefined,
 				loading: true,
 				staleTimeStamp: undefined
 			},
@@ -493,7 +451,7 @@ describe('createQuery', () => {
 		]);
 
 		expect(states2.value).toEqual([
-			// Initial state (already loading from query1)
+			// Initial state
 			{
 				data: undefined,
 				error: undefined,
@@ -506,7 +464,7 @@ describe('createQuery', () => {
 				loading: false,
 				staleTimeStamp: mockDate.getTime() + 2000
 			},
-			// incrementing to id 2 (from cache)
+			// incrementing to id 2 (not stale yet)
 			{
 				data: 'id is 2',
 				error: undefined,


### PR DESCRIPTION
Currently, when a query is initialised, its initial `loading` state is `false`. After all, the query did not start loading the data yet. Only when this happens (which is probably the next frame), the `loading` indicator switches to `true`.

There are two minor problems with this though:

- `{ data: undefined, loading: false }` looks as if the data was already loaded but yielded an undefined.
- There will initially be a (very) short delay and an unneeded re-render when displaying a spinner while `loading` is true

I think it is a good default to have each query act as if it is already loading when it is initialised AND it is stale.