### PR TITLE
Fix imports in final build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-tiny-query",
-	"version": "0.1.10",
+	"version": "0.1.11",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/Kidesia/svelte-tiny-query.git"

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,5 +1,5 @@
 export * from './svelte-tiny-query/query.svelte';
 export * from './svelte-tiny-query/sequential.svelte';
 export * from './svelte-tiny-query/invalidate.svelte';
-export * from './svelte-tiny-query/loadHelpers.ts';
+export * from './svelte-tiny-query/loadHelpers.js';
 export { globalLoading } from './svelte-tiny-query/cache.svelte';

--- a/src/lib/svelte-tiny-query/invalidate.svelte.ts
+++ b/src/lib/svelte-tiny-query/invalidate.svelte.ts
@@ -5,7 +5,7 @@ import {
 	errorByKey,
 	staleTimeStampByKey,
 	activeQueryCounts
-} from './cache.svelte.ts';
+} from './cache.svelte';
 
 /**
  * Invalidates queries based on the provided key.

--- a/src/lib/svelte-tiny-query/query.svelte.ts
+++ b/src/lib/svelte-tiny-query/query.svelte.ts
@@ -1,7 +1,7 @@
 import { untrack } from 'svelte';
 
-import { generateKey } from './utils.ts';
-import type { LoadResult } from './loadHelpers.ts';
+import { generateKey } from './utils.js';
+import type { LoadResult } from './loadHelpers.js';
 import {
 	queryLoaderByKey,
 	loadingByKey,
@@ -10,7 +10,7 @@ import {
 	staleTimeStampByKey,
 	activeQueryCounts,
 	globalLoading
-} from './cache.svelte.ts';
+} from './cache.svelte';
 
 /**
  * Represents the current state of a query.

--- a/src/lib/svelte-tiny-query/sequential.svelte.ts
+++ b/src/lib/svelte-tiny-query/sequential.svelte.ts
@@ -1,6 +1,6 @@
 import { untrack } from 'svelte';
 
-import { generateKey } from './utils.ts';
+import { generateKey } from './utils.js';
 import {
 	queryLoaderByKey,
 	loadingByKey,
@@ -9,7 +9,7 @@ import {
 	staleTimeStampByKey,
 	activeQueryCounts,
 	globalLoading
-} from './cache.svelte.ts';
+} from './cache.svelte';
 
 // Types
 

--- a/src/routes/examples/error-after-reload/+page.svelte
+++ b/src/routes/examples/error-after-reload/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createQuery } from '$lib/svelte-tiny-query/query.svelte.ts';
+	import { createQuery } from '$lib/svelte-tiny-query/query.svelte';
 
 	let i = $state(0);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
 		"strict": true,
 		// "noUncheckedIndexedAccess": true,
 		"noImplicitOverride": true,
-		"allowImportingTsExtensions": true
+		"allowImportingTsExtensions": true,
+
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,6 @@
 		"strict": true,
 		// "noUncheckedIndexedAccess": true,
 		"noImplicitOverride": true,
-		"allowImportingTsExtensions": true,
-
+		"allowImportingTsExtensions": true
 	}
 }


### PR DESCRIPTION
Seems that we need to always reference the .js versions of files, so the previous version would actually fail in some szenarios. https://svelte.dev/docs/kit/packaging