### PR TITLE
Adds loadedTimeStamp state, iterates on experimental sequentialQuery

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-tiny-query",
-	"version": "0.1.11",
+	"version": "0.1.12",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/Kidesia/svelte-tiny-query.git"

--- a/src/lib/svelte-tiny-query/cache.svelte.ts
+++ b/src/lib/svelte-tiny-query/cache.svelte.ts
@@ -2,6 +2,7 @@ export const queryLoaderByKey = $state({} as Record<string, () => void>);
 export const loadingByKey = $state({} as Record<string, boolean>);
 export const dataByKey = $state({} as Record<string, unknown>);
 export const errorByKey = $state({} as Record<string, unknown>);
+export const fetchedTimeStampByKey = $state({} as Record<string, number>);
 export const staleTimeStampByKey = $state({} as Record<string, number>);
 export const activeQueryCounts = $state({} as Record<string, number>);
 export const globalLoading = $state({ count: 0 });

--- a/src/lib/svelte-tiny-query/cache.svelte.ts
+++ b/src/lib/svelte-tiny-query/cache.svelte.ts
@@ -2,7 +2,7 @@ export const queryLoaderByKey = $state({} as Record<string, () => void>);
 export const loadingByKey = $state({} as Record<string, boolean>);
 export const dataByKey = $state({} as Record<string, unknown>);
 export const errorByKey = $state({} as Record<string, unknown>);
-export const fetchedTimeStampByKey = $state({} as Record<string, number>);
+export const loadedTimeStampByKey = $state({} as Record<string, number>);
 export const staleTimeStampByKey = $state({} as Record<string, number>);
 export const activeQueryCounts = $state({} as Record<string, number>);
 export const globalLoading = $state({ count: 0 });

--- a/src/lib/svelte-tiny-query/query.svelte.ts
+++ b/src/lib/svelte-tiny-query/query.svelte.ts
@@ -156,14 +156,14 @@ export function createQuery<TError, TParam = void, TData = unknown>(
 		});
 
 		$effect(() => {
-			// Update error wwhenever the key or the referenced data change
+			// Update error whenever the key or the referenced data change
 			queryState.error = errorByKey[internalState.currentKey] as
 				| TError
 				| undefined;
 		});
 
 		$effect(() => {
-			// Update staleTimeStamp whenever kwhenever the key or the referenced data change
+			// Update staleTimeStamp whenever the key or the referenced data change
 			queryState.staleTimeStamp = staleTimeStampByKey[internalState.currentKey];
 		});
 

--- a/src/lib/svelte-tiny-query/query.svelte.ts
+++ b/src/lib/svelte-tiny-query/query.svelte.ts
@@ -169,7 +169,8 @@ export function createQuery<TError, TParam = void, TData = unknown>(
 
 		$effect(() => {
 			// Update loadedTimeStamp whenever the key or the referenced data change
-			queryState.loadedTimeStamp = loadedTimeStampByKey[internalState.currentKey];
+			queryState.loadedTimeStamp =
+				loadedTimeStampByKey[internalState.currentKey];
 		});
 
 		$effect(() => {

--- a/src/lib/svelte-tiny-query/sequential.svelte.ts
+++ b/src/lib/svelte-tiny-query/sequential.svelte.ts
@@ -149,6 +149,7 @@ export function createSequentialQuery<TError, TData, TCursor, TParam = void>(
 				const alreadyLoading = loadingByKey[cacheKey];
 				const notFetchedYet = !loadedTimeStampByKey[cacheKey];
 
+				// We never consider sequential queries as stale (TODO: do!), so we don't check the staleTimeStamp here.
 				if (!alreadyLoading && notFetchedYet) {
 					queryLoaderWithParam();
 				}
@@ -166,7 +167,8 @@ export function createSequentialQuery<TError, TData, TCursor, TParam = void>(
 		return {
 			query: queryState,
 			reload: () => {
-				if (queryState.loading || !queryState.hasMore) return;
+				// TODO: allow reloading while its already loading (should then abort the previous request)
+				if (queryState.loading) return;
 				loadData(queryParam, true);
 			},
 			loadMore: () => {

--- a/src/lib/svelte-tiny-query/sequential.svelte.ts
+++ b/src/lib/svelte-tiny-query/sequential.svelte.ts
@@ -64,13 +64,11 @@ export function createSequentialQuery<TError, TData, TCursor, TParam = void>(
 	const loadData = async (queryParam: TParam, reload = false) => {
 		const cacheKey = generateKey(key, queryParam).join('__');
 
-		untrack(() => {
-			errorByKey[cacheKey] = undefined;
-			loadingByKey[cacheKey] = true;
-			globalLoading.count++;
-		});
+		errorByKey[cacheKey] = undefined;
+		loadingByKey[cacheKey] = true;
+		globalLoading.count++;
 
-		const cursor = untrack(() => cursorByKey[cacheKey] as TCursor | undefined);
+		const cursor = cursorByKey[cacheKey] as TCursor | undefined;
 		const loadResult = await loadFn(queryParam, !reload ? cursor : undefined);
 
 		if (loadResult.success) {
@@ -82,18 +80,14 @@ export function createSequentialQuery<TError, TData, TCursor, TParam = void>(
 				dataByKey[cacheKey] = [loadResult.data];
 			}
 
-			untrack(() => {
-				cursorByKey[cacheKey] = loadResult.cursor;
-				hasMoreByKey[cacheKey] = loadResult.cursor !== undefined;
-			});
+			cursorByKey[cacheKey] = loadResult.cursor;
+			hasMoreByKey[cacheKey] = loadResult.cursor !== undefined;
 		} else {
 			errorByKey[cacheKey] = loadResult.error;
 		}
 
-		untrack(() => {
-			loadingByKey[cacheKey] = false;
-			globalLoading.count--;
-		});
+		loadingByKey[cacheKey] = false;
+		globalLoading.count--;
 	};
 
 	return (queryParam: TParam) => {

--- a/src/lib/svelte-tiny-query/sequential.svelte.ts
+++ b/src/lib/svelte-tiny-query/sequential.svelte.ts
@@ -6,9 +6,9 @@ import {
 	loadingByKey,
 	dataByKey,
 	errorByKey,
-	staleTimeStampByKey,
 	activeQueryCounts,
-	globalLoading
+	globalLoading,
+	fetchedTimeStampByKey
 } from './cache.svelte';
 
 // Types
@@ -55,40 +55,6 @@ export function createSequentialQuery<TError, TData, TCursor, TParam = void>(
 	loadMore: () => void;
 	reload: () => void;
 } {
-	const initializeState = (currentKey: string) => {
-		const internal = $state({ currentKey });
-		const query: QueryState<TData, TError> = $state({
-			loading: false,
-			hasMore: undefined,
-			data: undefined,
-			error: undefined
-		});
-
-		$effect(() => {
-			query.loading = !!loadingByKey[internal.currentKey];
-		});
-
-		$effect(() => {
-			query.data =
-				internal.currentKey in dataByKey
-					? (dataByKey[internal.currentKey] as TData[])
-					: undefined;
-		});
-
-		$effect(() => {
-			query.error = errorByKey[internal.currentKey] as TError | undefined;
-		});
-
-		$effect(() => {
-			query.hasMore = hasMoreByKey[internal.currentKey];
-		});
-
-		return {
-			internal,
-			query
-		};
-	};
-
 	const loadData = async (queryParam: TParam, reload = false) => {
 		const cacheKey = generateKey(key, queryParam).join('__');
 
@@ -104,6 +70,7 @@ export function createSequentialQuery<TError, TData, TCursor, TParam = void>(
 		if (loadResult.success) {
 			if (Array.isArray(dataByKey[cacheKey]) && !reload) {
 				dataByKey[cacheKey].push(loadResult.data);
+				fetchedTimeStampByKey[cacheKey] = +new Date();
 			} else {
 				dataByKey[cacheKey] = [loadResult.data];
 			}
@@ -123,61 +90,80 @@ export function createSequentialQuery<TError, TData, TCursor, TParam = void>(
 	};
 
 	return (queryParam: TParam) => {
-		const cacheKey = generateKey(key, queryParam).join('__');
-		const { internal, query } = initializeState(cacheKey);
+		const internalState = $state({
+			currentKey: generateKey(key, queryParam).join('__')
+		});
+
+		const queryState: QueryState<TData, TError> = $state({
+			loading: false,
+			hasMore: undefined,
+			data: undefined,
+			error: undefined
+		});
 
 		$effect(() => {
-			const currentKey = generateKey(key, queryParam);
-			const cacheKey = currentKey.join('__');
-			internal.currentKey = cacheKey;
+			// Update loading whenever the key or the referenced data change
+			queryState.loading = !!loadingByKey[internalState.currentKey];
+		});
+
+		$effect(() => {
+			// Update data whenever the key or the referenced data change
+			queryState.data = dataByKey[internalState.currentKey] as
+				| TData[]
+				| undefined;
+		});
+
+		$effect(() => {
+			// Update error whenever the key or the referenced data change
+			queryState.error = errorByKey[internalState.currentKey] as
+				| TError
+				| undefined;
+		});
+
+		$effect(() => {
+			// Update hasMore whenever the key or the referenced data change
+			queryState.hasMore = hasMoreByKey[internalState.currentKey];
+		});
+
+		$effect(() => {
+			// Reset state and run the query loader when the queryParam changes
+			const cacheKey = generateKey(key, queryParam).join('__');
 
 			untrack(() => {
+				const frozenQueryParam = $state.snapshot(queryParam) as TParam;
+				const queryLoaderWithParam = () => {
+					loadData(frozenQueryParam);
+				};
+
 				activeQueryCounts[cacheKey] = (activeQueryCounts[cacheKey] ?? 0) + 1;
+				queryLoaderByKey[cacheKey] = queryLoaderWithParam;
+				internalState.currentKey = cacheKey;
+
+				const alreadyLoading = loadingByKey[cacheKey];
+				const notFetchedYet = !fetchedTimeStampByKey[cacheKey];
+
+				if (!alreadyLoading && notFetchedYet) {
+					queryLoaderWithParam();
+				}
 			});
-
-			const frozenQueryParam = $state.snapshot(queryParam) as TParam;
-			const queryLoaderInstance = () => {
-				loadData(frozenQueryParam);
-			};
-
-			untrack(() => {
-				queryLoaderByKey[cacheKey] = queryLoaderInstance;
-			});
-
-			const alreadyLoading = untrack(() => loadingByKey[cacheKey]);
-			const staleOrNew = untrack(() => {
-				const staleTime = staleTimeStampByKey[cacheKey];
-				return staleTime ? staleTime < +new Date() : true;
-			});
-
-			if (staleOrNew && !alreadyLoading) {
-				queryLoaderInstance();
-			}
 
 			return () => {
-				untrack(() => {
-					activeQueryCounts[cacheKey] = Math.max(
-						(activeQueryCounts[cacheKey] ?? 0) - 1,
-						0
-					);
-				});
+				// Decrement the active query count when the query is destroyed
+				activeQueryCounts[cacheKey] = Math.max(
+					(activeQueryCounts[cacheKey] ?? 0) - 1,
+					0
+				);
 			};
 		});
 
 		return {
-			query,
-			/**
-			 * Reloads the query.
-			 */
+			query: queryState,
 			reload: () => {
-				if (query.loading || !query.hasMore) return;
+				if (queryState.loading || !queryState.hasMore) return;
 				loadData(queryParam, true);
 			},
-			/**
-			 * Loads more data if available.
-			 */
 			loadMore: () => {
-				if (query.loading || !query.hasMore) return;
+				if (queryState.loading || !queryState.hasMore) return;
 				loadData(queryParam, false);
 			}
 		};

--- a/tests/createQuery.svelte.test.ts
+++ b/tests/createQuery.svelte.test.ts
@@ -30,6 +30,7 @@ describe('createQuery', () => {
 				data: undefined,
 				error: undefined,
 				loading: true,
+				loadedTimeStamp: undefined,
 				staleTimeStamp: undefined
 			},
 			// After loading
@@ -37,6 +38,7 @@ describe('createQuery', () => {
 				data: 'payload',
 				error: undefined,
 				loading: false,
+				loadedTimeStamp: mockDate.getTime(),
 				staleTimeStamp: mockDate.getTime()
 			}
 		]);
@@ -69,6 +71,7 @@ describe('createQuery', () => {
 				data: 'initial data',
 				error: undefined,
 				loading: true,
+				loadedTimeStamp: undefined,
 				staleTimeStamp: undefined
 			},
 			// After loading
@@ -76,6 +79,7 @@ describe('createQuery', () => {
 				data: 'updated data',
 				error: undefined,
 				loading: false,
+				loadedTimeStamp: mockDate.getTime(),
 				staleTimeStamp: mockDate.getTime()
 			}
 		]);
@@ -105,6 +109,7 @@ describe('createQuery', () => {
 				data: undefined,
 				error: undefined,
 				loading: true,
+				loadedTimeStamp: undefined,
 				staleTimeStamp: undefined
 			},
 			// After loading
@@ -112,6 +117,7 @@ describe('createQuery', () => {
 				data: undefined,
 				error: 'oopsie',
 				loading: false,
+				loadedTimeStamp: undefined,
 				staleTimeStamp: undefined
 			}
 		]);
@@ -157,6 +163,7 @@ describe('createQuery', () => {
 				data: undefined,
 				error: undefined,
 				loading: true,
+				loadedTimeStamp: undefined,
 				staleTimeStamp: undefined
 			},
 			// After loading
@@ -164,6 +171,7 @@ describe('createQuery', () => {
 				data: 'lucky you',
 				error: undefined,
 				loading: false,
+				loadedTimeStamp: mockDate.getTime(),
 				staleTimeStamp: mockDate.getTime()
 			},
 			// Refetching
@@ -171,6 +179,7 @@ describe('createQuery', () => {
 				data: 'lucky you',
 				error: undefined,
 				loading: true,
+				loadedTimeStamp: mockDate.getTime(),
 				staleTimeStamp: mockDate.getTime()
 			},
 			// After error (still has previous data)
@@ -178,6 +187,7 @@ describe('createQuery', () => {
 				data: 'lucky you',
 				error: 'oopsie',
 				loading: false,
+				loadedTimeStamp: mockDate.getTime(),
 				staleTimeStamp: mockDate.getTime()
 			}
 		]);
@@ -226,12 +236,14 @@ describe('createQuery', () => {
 				data: undefined,
 				error: undefined,
 				loading: true,
+				loadedTimeStamp: undefined,
 				staleTimeStamp: undefined
 			},
 			{
 				data: 'id is 1',
 				error: undefined,
 				loading: false,
+				loadedTimeStamp: mockDate.getTime(),
 				staleTimeStamp: mockDate.getTime()
 			},
 			// incrementing to id 2
@@ -239,12 +251,14 @@ describe('createQuery', () => {
 				data: undefined,
 				error: undefined,
 				loading: true,
+				loadedTimeStamp: undefined,
 				staleTimeStamp: undefined
 			},
 			{
 				data: 'id is 2',
 				error: undefined,
 				loading: false,
+				loadedTimeStamp: mockDate.getTime() + 1000,
 				staleTimeStamp: mockDate.getTime() + 1000
 			},
 			// decrementing back to id 1
@@ -252,12 +266,14 @@ describe('createQuery', () => {
 				data: 'id is 1',
 				error: undefined,
 				loading: true,
+				loadedTimeStamp: mockDate.getTime(),
 				staleTimeStamp: mockDate.getTime()
 			},
 			{
 				data: 'id is 1',
 				error: undefined,
 				loading: false,
+				loadedTimeStamp: mockDate.getTime() + 2000,
 				staleTimeStamp: mockDate.getTime() + 2000
 			}
 		]);
@@ -322,12 +338,14 @@ describe('createQuery', () => {
 				data: undefined,
 				error: undefined,
 				loading: true,
+				loadedTimeStamp: undefined,
 				staleTimeStamp: undefined
 			},
 			{
 				data: 'id is 1',
 				error: undefined,
 				loading: false,
+				loadedTimeStamp: mockDate.getTime(),
 				staleTimeStamp: expectedStaleTime
 			},
 			// incrementing to id 2
@@ -335,12 +353,14 @@ describe('createQuery', () => {
 				data: undefined,
 				error: undefined,
 				loading: true,
+				loadedTimeStamp: undefined,
 				staleTimeStamp: undefined
 			},
 			{
 				data: 'id is 2',
 				error: undefined,
 				loading: false,
+				loadedTimeStamp: mockDate.getTime() + 1000,
 				staleTimeStamp: expectedStaleTime + 1000
 			},
 			// decrementing back to id 1 (not stale yet)
@@ -348,6 +368,7 @@ describe('createQuery', () => {
 				data: 'id is 1',
 				error: undefined,
 				loading: false,
+				loadedTimeStamp: mockDate.getTime(),
 				staleTimeStamp: expectedStaleTime
 			},
 			// incrementing to id 2 (not stale yet)
@@ -355,6 +376,7 @@ describe('createQuery', () => {
 				data: 'id is 2',
 				error: undefined,
 				loading: false,
+				loadedTimeStamp: mockDate.getTime() + 1000,
 				staleTimeStamp: expectedStaleTime + 1000
 			},
 			// decrementing back to id 1 (now stale!)
@@ -362,12 +384,14 @@ describe('createQuery', () => {
 				data: 'id is 1',
 				error: undefined,
 				loading: true,
+				loadedTimeStamp: mockDate.getTime(),
 				staleTimeStamp: expectedStaleTime
 			},
 			{
 				data: 'id is 1',
 				error: undefined,
 				loading: false,
+				loadedTimeStamp: mockDate.getTime() + 4000,
 				staleTimeStamp: expectedStaleTime + 4000
 			}
 		]);
@@ -427,12 +451,14 @@ describe('createQuery', () => {
 				data: undefined,
 				error: undefined,
 				loading: true,
+				loadedTimeStamp: undefined,
 				staleTimeStamp: undefined
 			},
 			{
 				data: 'id is 1',
 				error: undefined,
 				loading: false,
+				loadedTimeStamp: mockDate.getTime(),
 				staleTimeStamp: mockDate.getTime() + 2000
 			},
 			// incrementing to id 2
@@ -440,12 +466,14 @@ describe('createQuery', () => {
 				data: undefined,
 				error: undefined,
 				loading: true,
+				loadedTimeStamp: undefined,
 				staleTimeStamp: undefined
 			},
 			{
 				data: 'id is 2',
 				error: undefined,
 				loading: false,
+				loadedTimeStamp: mockDate.getTime() + 1000,
 				staleTimeStamp: mockDate.getTime() + 3000
 			}
 		]);
@@ -456,12 +484,14 @@ describe('createQuery', () => {
 				data: undefined,
 				error: undefined,
 				loading: true,
+				loadedTimeStamp: undefined,
 				staleTimeStamp: undefined
 			},
 			{
 				data: 'id is 1',
 				error: undefined,
 				loading: false,
+				loadedTimeStamp: mockDate.getTime(),
 				staleTimeStamp: mockDate.getTime() + 2000
 			},
 			// incrementing to id 2 (from cache)
@@ -469,6 +499,7 @@ describe('createQuery', () => {
 				data: 'id is 2',
 				error: undefined,
 				loading: false,
+				loadedTimeStamp: mockDate.getTime() + 1000,
 				staleTimeStamp: mockDate.getTime() + 3000
 			}
 		]);


### PR DESCRIPTION
This PR adds the `loadedTimeStamp` property to the query state and iterates a wee bit on the as-of-yet experimental `createSequentialQuery`