### PR TITLE
Add experimental and undocumented udpateQueryData function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-tiny-query",
-	"version": "1.1.5",
+	"version": "1.1.6",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/Kidesia/svelte-tiny-query.git"

--- a/src/lib/svelte-tiny-query/invalidate.svelte.ts
+++ b/src/lib/svelte-tiny-query/invalidate.svelte.ts
@@ -68,8 +68,6 @@ export function updateQueryData(
 
 	Object.keys(activeQueryCounts).forEach((activeKey) => {
 		if (activeKey.startsWith(cacheKey) && activeQueryCounts[activeKey] > 0) {
-			console.log('Updating data for active key:', activeKey);
-			console.log('Current data:', $state.snapshot(dataByKey[activeKey]));
 			dataByKey[activeKey] = updater(dataByKey[activeKey]);
 		}
 	});

--- a/src/lib/svelte-tiny-query/invalidate.svelte.ts
+++ b/src/lib/svelte-tiny-query/invalidate.svelte.ts
@@ -66,8 +66,6 @@ export function updateQueryData(
 ) {
 	const cacheKey = key.join('__');
 
-	console.log('Updating query data for key:', cacheKey);
-
 	Object.keys(activeQueryCounts).forEach((activeKey) => {
 		if (activeKey.startsWith(cacheKey) && activeQueryCounts[activeKey] > 0) {
 			console.log('Updating data for active key:', activeKey);

--- a/src/lib/svelte-tiny-query/invalidate.svelte.ts
+++ b/src/lib/svelte-tiny-query/invalidate.svelte.ts
@@ -54,3 +54,25 @@ export function invalidateQueries(
 		}
 	});
 }
+
+/**
+ * Updates the cached data for a specific query key using an updater function.
+ * @param key The key of the query to update.
+ * @param updater A function that receives the current data and returns the updated data.
+ */
+export function updateQueryData(
+	key: string[],
+	updater: (currentData: unknown) => unknown
+) {
+	const cacheKey = key.join('__');
+
+	console.log('Updating query data for key:', cacheKey);
+
+	Object.keys(activeQueryCounts).forEach((activeKey) => {
+		if (activeKey.startsWith(cacheKey) && activeQueryCounts[activeKey] > 0) {
+			console.log('Updating data for active key:', activeKey);
+			console.log('Current data:', $state.snapshot(dataByKey[activeKey]));
+			dataByKey[activeKey] = updater(dataByKey[activeKey]);
+		}
+	});
+}


### PR DESCRIPTION
This PR adds the new function `updateQueryData` for svelte-tiny-query 1.1.6. **Do not use it yet** :)

There are some open questions around how this would work if more than one query matches the filter. Currently, you can then just update the data in all of the matching queries, which works fine for my current use-case, but i anticipate that this will be unexpected for other users.