### PR TITLE
Fix Query Edge Cases, Sequential Races and Add gcTime Cache Eviction

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ function createQuery<TError, TParam, TData>(
   options?: {
     initialData?: TData;
     staleTime?: number;
+    gcTime?: number;
   }
 ): (
   param?: TParam | (() => TParam),
@@ -148,6 +149,8 @@ You can use the helpers `succeed(data)` and `fail(error)` to construct these val
 
 - **initialData**: Used as the value of `data` before the query has first loaded (instead of `undefined`). When provided, the type of `query.data` is narrowed from `TData | undefined` to `TData`. Can be used to implement persisted queries.
 
+- **gcTime**: How long (in milliseconds) the cached state of the query is kept once the query is no longer used in any mounted component. When the time elapses, the cache for that key is evicted completely; using the query again cancels a pending eviction. If not set, cached data is kept for the lifetime of the app.
+
 #### Return: The Query Function
 
 ```typescript
@@ -159,7 +162,7 @@ You can use the helpers `succeed(data)` and `fail(error)` to construct these val
 
 The query function takes the query parameter (as a value or a thunk) and optional invoke options:
 
-- **enabled**: A reactive getter that controls whether the query loads. While it returns `false`, the query does not load and `loading` is `false`. When it flips to `true`, loading starts. Use this for dependent queries, e.g. `{ enabled: () => !!user.data }`.
+- **enabled**: A reactive getter that controls whether the query loads. While it returns `false`, the query does not load, `loading` is `false`, and `reload` (as well as `loadMore` on sequential queries) does nothing. When it flips to `true`, loading starts. Use this for dependent queries, e.g. `{ enabled: () => !!user.data }`.
 
 It returns the reactive query state:
 
@@ -189,6 +192,7 @@ function createSequentialQuery<TError, TParam, TData, TCursor>(
   options?: {
     initialData?: TData[];
     staleTime?: number;
+    gcTime?: number;
   }
 ): (
   param?: TParam | (() => TParam),
@@ -242,7 +246,7 @@ The state of a sequential query differs from a normal query:
 
 - **data** is an **array of pages** (`TData[]`), one entry per load.
 - **hasMore** indicates whether there is more data to load (`undefined` while loading).
-- **loadMore()** loads the next page using the current cursor.
+- **loadMore()** loads the next page using the current cursor (and does nothing when there is no more data).
 - **reload()** discards the pages and reloads from the start.
 
 Two more differences: `staleTime` defaults to `Infinity` (using a sequential query again does not automatically reload it), and when a stale sequential query reloads, all of its current pages are fetched again in order.
@@ -329,9 +333,6 @@ Use `initialData` to inject persisted data into the query.
 **Mutations**<br />
 Mutations can just be normal functions. Use `invalidateQueries` (or the experimental `updateQueryData`) to update queries after a mutation.
 
-**Cache Eviction**<br />
-Cached data is currently kept for the lifetime of the app. Cache eviction for inactive queries is on the roadmap.
-
 ## Migrating from 1.x
 
 Version 2 changed how parameters are passed to queries:
@@ -345,7 +346,6 @@ Version 2 changed how parameters are passed to queries:
 
 While we want to keep the library _tiny_, there are a few things on our plate:
 
-- Cache eviction for inactive queries
 - Retries on error
 - Query cancellation
 - Stabilize optimistic updates (`updateQueryData`)

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ You can use the helpers `succeed(data)` and `fail(error)` to construct these val
 
 - **initialData**: Used as the value of `data` before the query has first loaded (instead of `undefined`). When provided, the type of `query.data` is narrowed from `TData | undefined` to `TData`. Can be used to implement persisted queries.
 
-- **gcTime**: How long (in milliseconds) the cached state of the query is kept once the query is no longer used in any mounted component. When the time elapses, the cache for that key is evicted completely; using the query again cancels a pending eviction. If not set, cached data is kept for the lifetime of the app.
+- **gcTime**: Enables garbage collection for the query: its cached state is evicted `gcTime` milliseconds after the query is both **unused** (not part of any mounted component) and **stale**. Fresh data is never collected — with `staleTime: Infinity`, the cache is kept forever, so set that deliberately. Using the query again cancels a pending eviction. If `gcTime` is not set, cached data is kept for the lifetime of the app. You rarely need this — set it on queries whose parameter space is unbounded (search input, per-item detail views), where distinct cache keys accumulate over a session.
 
 #### Return: The Query Function
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-tiny-query",
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/Kidesia/svelte-tiny-query.git"

--- a/src/lib/svelte-tiny-query/cache.svelte.ts
+++ b/src/lib/svelte-tiny-query/cache.svelte.ts
@@ -7,6 +7,11 @@ export const queryLoaderByKey = {} as Record<
 	(mode?: QueryLoadMode) => Promise<void>
 >;
 
+export const evictionTimerByKey = {} as Record<
+	string,
+	ReturnType<typeof setTimeout>
+>;
+
 // Query State
 
 export const loadingByKey = $state({} as Record<string, boolean>);

--- a/src/lib/svelte-tiny-query/invalidate.svelte.ts
+++ b/src/lib/svelte-tiny-query/invalidate.svelte.ts
@@ -3,6 +3,7 @@ import {
 	loadingByKey,
 	dataByKey,
 	errorByKey,
+	loadedTimeStampByKey,
 	staleTimeStampByKey,
 	activeQueryCounts,
 	hasMoreByKey,
@@ -38,16 +39,25 @@ export function invalidateQueries(
 		}
 	});
 
-	// Reset the cache data of the matching queries if forced
+	// Forget all cached state of the matching queries if forced. Each record
+	// is cleared separately, so that queries which only ever produced an
+	// error (and thus have no data entry) are also fully reset.
 	if (options?.force) {
-		Object.keys(dataByKey).forEach((key) => {
-			if (matches(key)) {
-				delete loadingByKey[key];
-				delete dataByKey[key];
-				delete errorByKey[key];
-				delete hasMoreByKey[key];
-				delete cursorByKey[key];
-			}
+		const records = [
+			loadingByKey,
+			dataByKey,
+			errorByKey,
+			loadedTimeStampByKey,
+			staleTimeStampByKey,
+			hasMoreByKey,
+			cursorByKey
+		];
+		records.forEach((record) => {
+			Object.keys(record).forEach((key) => {
+				if (matches(key)) {
+					delete record[key];
+				}
+			});
 		});
 	}
 

--- a/src/lib/svelte-tiny-query/query.svelte.ts
+++ b/src/lib/svelte-tiny-query/query.svelte.ts
@@ -207,6 +207,7 @@ export function createQuery<TData, TError, TParam extends QueryParam = void>(
 				return isEnabled();
 			},
 			reload: () => {
+				if (!isEnabled()) return;
 				queryLoaderByKey[internalState.currentKey]?.();
 			}
 		};

--- a/src/lib/svelte-tiny-query/query.svelte.ts
+++ b/src/lib/svelte-tiny-query/query.svelte.ts
@@ -187,10 +187,12 @@ export function createQuery<TData, TError, TParam extends QueryParam = void>(
 				return isLoading === undefined ? true : isLoading;
 			},
 			get data() {
-				return (
-					(dataByKey[internalState.currentKey] as TData | undefined) ??
-					options?.initialData
-				);
+				const currentKey = internalState.currentKey;
+				// "in" instead of "??", so that null/undefined data does not
+				// fall back to initialData once the query has loaded
+				return currentKey in dataByKey
+					? (dataByKey[currentKey] as TData)
+					: options?.initialData;
 			},
 			get error() {
 				return errorByKey[internalState.currentKey] as TError | undefined;

--- a/src/lib/svelte-tiny-query/query.svelte.ts
+++ b/src/lib/svelte-tiny-query/query.svelte.ts
@@ -80,8 +80,9 @@ export function createQuery<
 		staleTime?: number;
 		/**
 		 * Time in milliseconds after which the cached state of the query is
-		 * evicted, once the query is no longer used in any mounted component.
-		 * If not set, cached data is kept for the lifetime of the app.
+		 * evicted, once the query is unused in any mounted component AND its
+		 * data is stale. Fresh data is never evicted (with staleTime Infinity,
+		 * the cache is kept forever). If not set, cached data is never evicted.
 		 */
 		gcTime?: number;
 	}
@@ -123,8 +124,9 @@ export function createQuery<
 		staleTime?: number;
 		/**
 		 * Time in milliseconds after which the cached state of the query is
-		 * evicted, once the query is no longer used in any mounted component.
-		 * If not set, cached data is kept for the lifetime of the app.
+		 * evicted, once the query is unused in any mounted component AND its
+		 * data is stale. Fresh data is never evicted (with staleTime Infinity,
+		 * the cache is kept forever). If not set, cached data is never evicted.
 		 */
 		gcTime?: number;
 	}

--- a/src/lib/svelte-tiny-query/query.svelte.ts
+++ b/src/lib/svelte-tiny-query/query.svelte.ts
@@ -78,6 +78,12 @@ export function createQuery<
 		 * A stale query will be automatically re-fetched when accessed.
 		 */
 		staleTime?: number;
+		/**
+		 * Time in milliseconds after which the cached state of the query is
+		 * evicted, once the query is no longer used in any mounted component.
+		 * If not set, cached data is kept for the lifetime of the app.
+		 */
+		gcTime?: number;
 	}
 ): (
 	param?: TParam | (() => TParam),
@@ -115,6 +121,12 @@ export function createQuery<
 		 * A stale query will be automatically re-fetched when accessed.
 		 */
 		staleTime?: number;
+		/**
+		 * Time in milliseconds after which the cached state of the query is
+		 * evicted, once the query is no longer used in any mounted component.
+		 * If not set, cached data is kept for the lifetime of the app.
+		 */
+		gcTime?: number;
 	}
 ): (
 	param?: TParam | (() => TParam),
@@ -127,6 +139,7 @@ export function createQuery<TData, TError, TParam extends QueryParam = void>(
 	options?: {
 		initialData?: TData;
 		staleTime?: number;
+		gcTime?: number;
 	}
 ): (
 	param?: TParam | (() => TParam),
@@ -147,7 +160,7 @@ export function createQuery<TData, TError, TParam extends QueryParam = void>(
 		warnIfTracking('createQuery', internalState.currentKey);
 
 		// Register the active query (and unregister later)
-		trackActiveQueriesCount(key, getParam);
+		trackActiveQueriesCount(key, getParam, options?.gcTime);
 
 		$effect(() => {
 			// Track enabled reactively — if disabled, skip loading

--- a/src/lib/svelte-tiny-query/queryHelpers.svelte.ts
+++ b/src/lib/svelte-tiny-query/queryHelpers.svelte.ts
@@ -51,8 +51,8 @@ export function trackActiveQueriesCount(
 			const count = (activeQueryCounts[cacheKey] ?? 0) - 1;
 			if (count <= 0) {
 				delete activeQueryCounts[cacheKey];
-				if (gcTime !== undefined && gcTime !== Infinity) {
-					scheduleEviction(cacheKey, gcTime);
+				if (gcTime !== undefined) {
+					scheduleEviction(cacheKey, gcTime, gcTime);
 				}
 			} else {
 				activeQueryCounts[cacheKey] = count;
@@ -61,25 +61,54 @@ export function trackActiveQueriesCount(
 	});
 }
 
-function scheduleEviction(cacheKey: string, gcTime: number) {
+// setTimeout treats delays above 2^31 - 1 as 0, so cap reschedules to
+// this and re-check when the timer fires
+const MAX_TIMEOUT_DELAY = 2 ** 31 - 1;
+
+function scheduleEviction(cacheKey: string, gcTime: number, delay: number) {
 	clearTimeout(evictionTimerByKey[cacheKey]);
-	evictionTimerByKey[cacheKey] = setTimeout(() => {
-		delete evictionTimerByKey[cacheKey];
+	delete evictionTimerByKey[cacheKey];
 
-		// Skip eviction if the query became active again or is loading
-		if (activeQueryCounts[cacheKey] || loadingByKey[cacheKey]) {
-			return;
-		}
+	// An infinite delay (gcTime or staleTime of Infinity) means the
+	// query is never evicted
+	if (!Number.isFinite(delay)) return;
 
-		delete queryLoaderByKey[cacheKey];
-		delete loadingByKey[cacheKey];
-		delete dataByKey[cacheKey];
-		delete errorByKey[cacheKey];
-		delete loadedTimeStampByKey[cacheKey];
-		delete staleTimeStampByKey[cacheKey];
-		delete cursorByKey[cacheKey];
-		delete hasMoreByKey[cacheKey];
-	}, gcTime);
+	evictionTimerByKey[cacheKey] = setTimeout(
+		() => evictIfUnusedAndStale(cacheKey, gcTime),
+		Math.min(delay, MAX_TIMEOUT_DELAY)
+	);
+}
+
+function evictIfUnusedAndStale(cacheKey: string, gcTime: number) {
+	delete evictionTimerByKey[cacheKey];
+
+	// The query became active again in the meantime
+	if (activeQueryCounts[cacheKey]) return;
+
+	// Wait for an in-flight load to finish before deciding
+	if (loadingByKey[cacheKey]) {
+		scheduleEviction(cacheKey, gcTime, gcTime);
+		return;
+	}
+
+	// A query is evicted gcTime after it is both unused and stale, so
+	// fresh data is never collected. A query without a stale timestamp
+	// (it only ever produced an error) counts as stale.
+	const staleTimeStamp = staleTimeStampByKey[cacheKey] ?? 0;
+	const remaining = staleTimeStamp + gcTime - Date.now();
+	if (remaining > 0) {
+		scheduleEviction(cacheKey, gcTime, remaining);
+		return;
+	}
+
+	delete queryLoaderByKey[cacheKey];
+	delete loadingByKey[cacheKey];
+	delete dataByKey[cacheKey];
+	delete errorByKey[cacheKey];
+	delete loadedTimeStampByKey[cacheKey];
+	delete staleTimeStampByKey[cacheKey];
+	delete cursorByKey[cacheKey];
+	delete hasMoreByKey[cacheKey];
 }
 
 export async function withLoading<TData, TError>(

--- a/src/lib/svelte-tiny-query/queryHelpers.svelte.ts
+++ b/src/lib/svelte-tiny-query/queryHelpers.svelte.ts
@@ -53,11 +53,12 @@ export async function withLoading<TData, TError>(
 	staleTime = 0,
 	force = false
 ) {
-	// Check if the query is already loading or still has fresh data
+	// Skip if this query is already loading (loads are never concurrent per
+	// key, not even when forced) or if it still has fresh data (unless forced)
 	const alreadyLoading = loadingByKey[key];
 	const alreadyLoaded = !!loadedTimeStampByKey[key];
 	const staleData = staleTimeStampByKey[key] <= Date.now();
-	if (!force && (alreadyLoading || (alreadyLoaded && !staleData))) {
+	if (alreadyLoading || (!force && alreadyLoaded && !staleData)) {
 		return;
 	}
 

--- a/src/lib/svelte-tiny-query/queryHelpers.svelte.ts
+++ b/src/lib/svelte-tiny-query/queryHelpers.svelte.ts
@@ -5,7 +5,11 @@ import {
 	errorByKey,
 	loadedTimeStampByKey,
 	staleTimeStampByKey,
-	dataByKey
+	dataByKey,
+	queryLoaderByKey,
+	evictionTimerByKey,
+	cursorByKey,
+	hasMoreByKey
 } from './cache.svelte';
 import type { LoadResult } from './loadHelpers.js';
 import { generateCacheKey } from './utils.js';
@@ -25,12 +29,19 @@ export function warnIfTracking(fnName: string, key: string) {
 export function trackActiveQueriesCount(
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	key: string[] | ((p: any) => string[]),
-	paramGetter: () => unknown
+	paramGetter: () => unknown,
+	gcTime?: number
 ) {
 	$effect(() => {
 		const cacheKey = generateCacheKey(key, paramGetter());
 
 		untrack(() => {
+			// Cancel a pending eviction when the query becomes active again
+			if (cacheKey in evictionTimerByKey) {
+				clearTimeout(evictionTimerByKey[cacheKey]);
+				delete evictionTimerByKey[cacheKey];
+			}
+
 			// Increment the active query count for this cache key
 			activeQueryCounts[cacheKey] = (activeQueryCounts[cacheKey] ?? 0) + 1;
 		});
@@ -40,11 +51,35 @@ export function trackActiveQueriesCount(
 			const count = (activeQueryCounts[cacheKey] ?? 0) - 1;
 			if (count <= 0) {
 				delete activeQueryCounts[cacheKey];
+				if (gcTime !== undefined && gcTime !== Infinity) {
+					scheduleEviction(cacheKey, gcTime);
+				}
 			} else {
 				activeQueryCounts[cacheKey] = count;
 			}
 		};
 	});
+}
+
+function scheduleEviction(cacheKey: string, gcTime: number) {
+	clearTimeout(evictionTimerByKey[cacheKey]);
+	evictionTimerByKey[cacheKey] = setTimeout(() => {
+		delete evictionTimerByKey[cacheKey];
+
+		// Skip eviction if the query became active again or is loading
+		if (activeQueryCounts[cacheKey] || loadingByKey[cacheKey]) {
+			return;
+		}
+
+		delete queryLoaderByKey[cacheKey];
+		delete loadingByKey[cacheKey];
+		delete dataByKey[cacheKey];
+		delete errorByKey[cacheKey];
+		delete loadedTimeStampByKey[cacheKey];
+		delete staleTimeStampByKey[cacheKey];
+		delete cursorByKey[cacheKey];
+		delete hasMoreByKey[cacheKey];
+	}, gcTime);
 }
 
 export async function withLoading<TData, TError>(

--- a/src/lib/svelte-tiny-query/sequential.svelte.ts
+++ b/src/lib/svelte-tiny-query/sequential.svelte.ts
@@ -131,58 +131,23 @@ export function createSequentialQuery<
 		const isEnabled = invokeOptions?.enabled ?? (() => true);
 
 		// Helpers
-		const loadData = async (
-			queryParam: TParam,
-			cacheKey: string,
-			mode: QueryLoadMode,
-			currentData: TData[] | undefined = undefined
-		) => {
-			const cursor = cursorByKey[cacheKey] as TCursor | undefined;
 
-			const loadResult = await loadFn(
-				queryParam,
-				mode === 'more' ? cursor : undefined
-			);
-
-			if (!loadResult.success) return loadResult;
-
-			cursorByKey[cacheKey] = loadResult.cursor;
-			hasMoreByKey[cacheKey] = loadResult.cursor !== undefined;
-
-			let newData = currentData ? [...currentData] : [];
-
-			if (Array.isArray(currentData) && mode === 'more') {
-				newData.push(loadResult.data);
-			} else {
-				newData = [loadResult.data];
-			}
-
-			return {
-				success: true as const,
-				data: newData
-			};
-		};
-
-		const reloadAllPages = async (queryParam: TParam, cacheKey: string) => {
-			const currentData = dataByKey[cacheKey] as TData[] | undefined;
-			const numPages = currentData?.length ?? 1;
-			let newData = [] as TData[];
+		// Loads pages sequentially from the start (up to numPages), stopping
+		// early when there is no more data
+		const loadPagesFromStart = async (queryParam: TParam, numPages: number) => {
+			const pages: TData[] = [];
+			let cursor: TCursor | undefined = undefined;
 
 			for (let i = 0; i < numPages; i++) {
-				const loadResult = await loadData(
-					queryParam,
-					cacheKey,
-					i === 0 ? 'load' : 'more',
-					newData
-				);
+				const loadResult = await loadFn(queryParam, cursor);
 				if (!loadResult.success) return loadResult;
-				newData = loadResult.data;
+
+				pages.push(loadResult.data);
+				cursor = loadResult.cursor;
+				if (cursor === undefined) break;
 			}
 
-			return {
-				success: true as const,
-				data: newData
-			};
+			return { success: true as const, data: pages, cursor };
 		};
 
 		// State
@@ -213,20 +178,45 @@ export function createSequentialQuery<
 					const queryLoaderWithParam = async (mode?: QueryLoadMode) => {
 						withLoading(
 							cacheKey,
-							() => {
-								switch (mode) {
-									case 'more':
-										return loadData(
-											frozenQueryParam,
-											cacheKey,
-											mode,
-											dataByKey[cacheKey] as TData[] | undefined
-										);
-									case 'reload':
-										return loadData(frozenQueryParam, cacheKey, mode);
-									default:
-										return reloadAllPages(frozenQueryParam, cacheKey);
+							async () => {
+								// Load the next page and append it to the current data
+								if (mode === 'more') {
+									const currentData = dataByKey[cacheKey] as
+										| TData[]
+										| undefined;
+									const cursor = cursorByKey[cacheKey] as TCursor | undefined;
+
+									const loadResult = await loadFn(frozenQueryParam, cursor);
+									if (!loadResult.success) return loadResult;
+
+									cursorByKey[cacheKey] = loadResult.cursor;
+									hasMoreByKey[cacheKey] = loadResult.cursor !== undefined;
+									return {
+										success: true as const,
+										data: [...(currentData ?? []), loadResult.data]
+									};
 								}
+
+								// Reload only the first page ('reload'), or all current
+								// pages (initial load and invalidation)
+								const numPages =
+									mode === 'reload'
+										? 1
+										: ((dataByKey[cacheKey] as TData[] | undefined)?.length ??
+											1);
+
+								const loadResult = await loadPagesFromStart(
+									frozenQueryParam,
+									numPages
+								);
+								if (!loadResult.success) return loadResult;
+
+								// Cursor and hasMore are only updated after all pages have
+								// loaded, so a failed reload leaves them consistent with
+								// the (kept) previous data
+								cursorByKey[cacheKey] = loadResult.cursor;
+								hasMoreByKey[cacheKey] = loadResult.cursor !== undefined;
+								return { success: true as const, data: loadResult.data };
 							},
 							options?.staleTime ?? Infinity,
 							mode !== undefined
@@ -274,6 +264,8 @@ export function createSequentialQuery<
 			},
 			loadMore: () => {
 				if (!isEnabled()) return;
+				// There is nothing more to load
+				if (hasMoreByKey[internalState.currentKey] === false) return;
 				queryLoaderByKey[internalState.currentKey]?.('more');
 			},
 			reload: () => {

--- a/src/lib/svelte-tiny-query/sequential.svelte.ts
+++ b/src/lib/svelte-tiny-query/sequential.svelte.ts
@@ -248,10 +248,12 @@ export function createSequentialQuery<
 				return isLoading === undefined ? true : isLoading;
 			},
 			get data() {
-				return (
-					(dataByKey[internalState.currentKey] as TData[] | undefined) ??
-					options?.initialData
-				);
+				const currentKey = internalState.currentKey;
+				// "in" instead of "??", so that pages of null/undefined data do
+				// not fall back to initialData once the query has loaded
+				return currentKey in dataByKey
+					? (dataByKey[currentKey] as TData[])
+					: options?.initialData;
 			},
 			get hasMore() {
 				return loadingByKey[internalState.currentKey]

--- a/src/lib/svelte-tiny-query/sequential.svelte.ts
+++ b/src/lib/svelte-tiny-query/sequential.svelte.ts
@@ -273,9 +273,11 @@ export function createSequentialQuery<
 				return isEnabled();
 			},
 			loadMore: () => {
+				if (!isEnabled()) return;
 				queryLoaderByKey[internalState.currentKey]?.('more');
 			},
 			reload: () => {
+				if (!isEnabled()) return;
 				queryLoaderByKey[internalState.currentKey]?.('reload');
 			}
 		};

--- a/src/lib/svelte-tiny-query/sequential.svelte.ts
+++ b/src/lib/svelte-tiny-query/sequential.svelte.ts
@@ -78,6 +78,7 @@ export function createSequentialQuery<
 	options: {
 		initialData: TData[];
 		staleTime?: number;
+		gcTime?: number;
 	}
 ): (
 	param?: TParam | (() => TParam),
@@ -98,6 +99,7 @@ export function createSequentialQuery<
 	options?: {
 		initialData?: TData[];
 		staleTime?: number;
+		gcTime?: number;
 	}
 ): (
 	param?: TParam | (() => TParam),
@@ -118,6 +120,7 @@ export function createSequentialQuery<
 	options?: {
 		initialData?: TData[];
 		staleTime?: number;
+		gcTime?: number;
 	}
 ): (
 	param?: TParam | (() => TParam),
@@ -158,7 +161,7 @@ export function createSequentialQuery<
 
 		warnIfTracking('createSequentialQuery', internalState.currentKey);
 
-		trackActiveQueriesCount(key, getParam);
+		trackActiveQueriesCount(key, getParam, options?.gcTime);
 
 		$effect(() => {
 			// Track enabled reactively — if disabled, skip loading

--- a/tests/createQuery/NoParam.svelte
+++ b/tests/createQuery/NoParam.svelte
@@ -17,6 +17,7 @@
 		queryOptions?: {
 			staleTime?: number;
 			initialData?: unknown;
+			gcTime?: number;
 		};
 	} = $props();
 

--- a/tests/createQuery/gcTime.svelte.test.ts
+++ b/tests/createQuery/gcTime.svelte.test.ts
@@ -10,7 +10,7 @@ import {
 import NoParam from './NoParam.svelte';
 
 describe('Normal Query - gcTime Option', () => {
-	test('Evicts all cached state after gcTime when inactive', async () => {
+	test('Evicts all cached state after gcTime when inactive and stale', async () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(new Date(2025, 5, 11, 12, 0, 0));
 
@@ -19,13 +19,14 @@ describe('Normal Query - gcTime Option', () => {
 			data: 'payload'
 		}));
 
+		// Default staleTime of 0: the data is stale as soon as it loads
 		const states = $state({ value: [] });
 		const rendered = render(NoParam, {
 			props: {
 				states,
 				key: ['gc-eviction-test'],
 				loadingFn: mockLoadingFn,
-				queryOptions: { staleTime: Infinity, gcTime: 5000 }
+				queryOptions: { gcTime: 5000 }
 			}
 		});
 
@@ -53,7 +54,7 @@ describe('Normal Query - gcTime Option', () => {
 				states: states2,
 				key: ['gc-eviction-test'],
 				loadingFn: mockLoadingFn,
-				queryOptions: { staleTime: Infinity, gcTime: 5000 }
+				queryOptions: { gcTime: 5000 }
 			}
 		});
 
@@ -63,6 +64,93 @@ describe('Normal Query - gcTime Option', () => {
 		expect(mockLoadingFn).toHaveBeenCalledTimes(2);
 
 		rendered2.unmount();
+		vi.useRealTimers();
+	});
+
+	test('Fresh data is not evicted until stale for gcTime', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(2025, 5, 11, 12, 0, 0));
+
+		const states = $state({ value: [] });
+		const rendered = render(NoParam, {
+			props: {
+				states,
+				key: ['gc-fresh-test'],
+				loadingFn: async () => ({ success: true, data: 'payload' }),
+				queryOptions: { staleTime: 10000, gcTime: 5000 }
+			}
+		});
+
+		await waitFor(() => {
+			expect(rendered.queryByText('Data: payload')).toBeInTheDocument();
+		});
+		rendered.unmount();
+
+		// Unused for gcTime, but the data is still fresh — no eviction
+		vi.advanceTimersByTime(5001);
+		expect(dataByKey['gc-fresh-test']).toBe('payload');
+
+		// Data goes stale at 10000, so eviction happens at 15000
+		vi.advanceTimersByTime(9998);
+		expect(dataByKey['gc-fresh-test']).toBe('payload');
+
+		vi.advanceTimersByTime(1);
+		expect('gc-fresh-test' in dataByKey).toBe(false);
+
+		vi.useRealTimers();
+	});
+
+	test('Data with staleTime Infinity is never evicted', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(2025, 5, 11, 12, 0, 0));
+
+		const states = $state({ value: [] });
+		const rendered = render(NoParam, {
+			props: {
+				states,
+				key: ['gc-never-stale-test'],
+				loadingFn: async () => ({ success: true, data: 'payload' }),
+				queryOptions: { staleTime: Infinity, gcTime: 5000 }
+			}
+		});
+
+		await waitFor(() => {
+			expect(rendered.queryByText('Data: payload')).toBeInTheDocument();
+		});
+		rendered.unmount();
+
+		// The data never goes stale, so it is never collected
+		vi.advanceTimersByTime(1000 * 60 * 60 * 24 * 365);
+		expect(dataByKey['gc-never-stale-test']).toBe('payload');
+
+		vi.useRealTimers();
+	});
+
+	test('Evicts queries that only ever produced an error', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(2025, 5, 11, 12, 0, 0));
+
+		const states = $state({ value: [] });
+		const rendered = render(NoParam, {
+			props: {
+				states,
+				key: ['gc-error-test'],
+				loadingFn: async () => ({ success: false, error: 'oopsie' }),
+				queryOptions: { gcTime: 5000 }
+			}
+		});
+
+		await waitFor(() => {
+			expect(rendered.queryByText('Error: oopsie')).toBeInTheDocument();
+		});
+		expect(errorByKey['gc-error-test']).toBe('oopsie');
+		rendered.unmount();
+
+		// A query without data counts as stale and is evicted after gcTime
+		vi.advanceTimersByTime(5000);
+		expect('gc-error-test' in errorByKey).toBe(false);
+		expect('gc-error-test' in queryLoaderByKey).toBe(false);
+
 		vi.useRealTimers();
 	});
 
@@ -81,7 +169,7 @@ describe('Normal Query - gcTime Option', () => {
 				states,
 				key: ['gc-cancel-test'],
 				loadingFn: mockLoadingFn,
-				queryOptions: { staleTime: Infinity, gcTime: 5000 }
+				queryOptions: { staleTime: 10000, gcTime: 5000 }
 			}
 		});
 
@@ -99,7 +187,7 @@ describe('Normal Query - gcTime Option', () => {
 				states: states2,
 				key: ['gc-cancel-test'],
 				loadingFn: mockLoadingFn,
-				queryOptions: { staleTime: Infinity, gcTime: 5000 }
+				queryOptions: { staleTime: 10000, gcTime: 5000 }
 			}
 		});
 

--- a/tests/createQuery/gcTime.svelte.test.ts
+++ b/tests/createQuery/gcTime.svelte.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/svelte/svelte5';
+
+import {
+	dataByKey,
+	errorByKey,
+	loadedTimeStampByKey,
+	queryLoaderByKey
+} from '../../src/lib/svelte-tiny-query/cache.svelte';
+import NoParam from './NoParam.svelte';
+
+describe('Normal Query - gcTime Option', () => {
+	test('Evicts all cached state after gcTime when inactive', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(2025, 5, 11, 12, 0, 0));
+
+		const mockLoadingFn = vi.fn(async () => ({
+			success: true as const,
+			data: 'payload'
+		}));
+
+		const states = $state({ value: [] });
+		const rendered = render(NoParam, {
+			props: {
+				states,
+				key: ['gc-eviction-test'],
+				loadingFn: mockLoadingFn,
+				queryOptions: { staleTime: Infinity, gcTime: 5000 }
+			}
+		});
+
+		await waitFor(() => {
+			expect(rendered.queryByText('Data: payload')).toBeInTheDocument();
+		});
+		expect(dataByKey['gc-eviction-test']).toBe('payload');
+
+		// While inactive but before gcTime, the cache is kept
+		rendered.unmount();
+		vi.advanceTimersByTime(4999);
+		expect(dataByKey['gc-eviction-test']).toBe('payload');
+
+		// After gcTime, all cached state is evicted
+		vi.advanceTimersByTime(1);
+		expect('gc-eviction-test' in dataByKey).toBe(false);
+		expect('gc-eviction-test' in errorByKey).toBe(false);
+		expect('gc-eviction-test' in loadedTimeStampByKey).toBe(false);
+		expect('gc-eviction-test' in queryLoaderByKey).toBe(false);
+
+		// Using the query again loads fresh data
+		const states2 = $state({ value: [] });
+		const rendered2 = render(NoParam, {
+			props: {
+				states: states2,
+				key: ['gc-eviction-test'],
+				loadingFn: mockLoadingFn,
+				queryOptions: { staleTime: Infinity, gcTime: 5000 }
+			}
+		});
+
+		await waitFor(() => {
+			expect(rendered2.queryByText('Data: payload')).toBeInTheDocument();
+		});
+		expect(mockLoadingFn).toHaveBeenCalledTimes(2);
+
+		rendered2.unmount();
+		vi.useRealTimers();
+	});
+
+	test('Becoming active again within gcTime cancels the eviction', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(2025, 5, 11, 12, 0, 0));
+
+		const mockLoadingFn = vi.fn(async () => ({
+			success: true as const,
+			data: 'payload'
+		}));
+
+		const states = $state({ value: [] });
+		const rendered = render(NoParam, {
+			props: {
+				states,
+				key: ['gc-cancel-test'],
+				loadingFn: mockLoadingFn,
+				queryOptions: { staleTime: Infinity, gcTime: 5000 }
+			}
+		});
+
+		await waitFor(() => {
+			expect(rendered.queryByText('Data: payload')).toBeInTheDocument();
+		});
+
+		// Unmount and remount before gcTime elapses
+		rendered.unmount();
+		vi.advanceTimersByTime(2000);
+
+		const states2 = $state({ value: [] });
+		const rendered2 = render(NoParam, {
+			props: {
+				states: states2,
+				key: ['gc-cancel-test'],
+				loadingFn: mockLoadingFn,
+				queryOptions: { staleTime: Infinity, gcTime: 5000 }
+			}
+		});
+
+		await waitFor(() => {
+			expect(rendered2.queryByText('Data: payload')).toBeInTheDocument();
+		});
+
+		// The eviction was cancelled, the cache stays warm indefinitely
+		// while the query is active
+		vi.advanceTimersByTime(60000);
+		expect(dataByKey['gc-cancel-test']).toBe('payload');
+
+		// Data came from the cache, no second load happened
+		expect(mockLoadingFn).toHaveBeenCalledTimes(1);
+
+		rendered2.unmount();
+		vi.useRealTimers();
+	});
+
+	test('Without gcTime, the cache is kept indefinitely', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(2025, 5, 11, 12, 0, 0));
+
+		const states = $state({ value: [] });
+		const rendered = render(NoParam, {
+			props: {
+				states,
+				key: ['gc-none-test'],
+				loadingFn: async () => ({ success: true, data: 'payload' })
+			}
+		});
+
+		await waitFor(() => {
+			expect(rendered.queryByText('Data: payload')).toBeInTheDocument();
+		});
+
+		rendered.unmount();
+		vi.advanceTimersByTime(1000 * 60 * 60 * 24);
+		expect(dataByKey['gc-none-test']).toBe('payload');
+
+		vi.useRealTimers();
+	});
+});

--- a/tests/createQuery/noParam.svelte.test.ts
+++ b/tests/createQuery/noParam.svelte.test.ts
@@ -1118,6 +1118,49 @@ describe('Normal Query - Enabled Option', () => {
 		vi.useRealTimers();
 	});
 
+	test('Reload does nothing after the query becomes disabled', async () => {
+		vi.useFakeTimers();
+		const mockDate = new Date(2025, 5, 11, 12, 0, 0);
+		vi.setSystemTime(mockDate);
+
+		const mockLoadingFn = vi.fn(async () => ({
+			success: true as const,
+			data: 'payload'
+		}));
+
+		const states = $state({ value: [] });
+		const rendered = render(WithEnabled, {
+			props: {
+				states,
+				key: ['enabled-then-disabled-reload-test'],
+				loadingFn: mockLoadingFn,
+				initialEnabled: true
+			}
+		});
+
+		// The enabled query loads normally (the loader now exists)
+		await waitFor(() => {
+			expect(rendered.queryByText('Data: payload')).toBeInTheDocument();
+		});
+		expect(mockLoadingFn).toHaveBeenCalledTimes(1);
+
+		// Disable the query
+		rendered.queryByText('Toggle Enabled')?.click();
+		await waitFor(() => {
+			expect(rendered.queryByText('Enabled: false')).toBeInTheDocument();
+		});
+
+		// Reload must not trigger the (existing) loader while disabled
+		vi.advanceTimersByTime(1000);
+		rendered.queryByText('Reload')?.click();
+		await vi.advanceTimersByTimeAsync(100);
+
+		expect(mockLoadingFn).toHaveBeenCalledTimes(1);
+
+		rendered.unmount();
+		vi.useRealTimers();
+	});
+
 	test('Reload does nothing while disabled', async () => {
 		vi.useFakeTimers();
 		const mockDate = new Date(2025, 5, 11, 12, 0, 0);

--- a/tests/createQuery/noParam.svelte.test.ts
+++ b/tests/createQuery/noParam.svelte.test.ts
@@ -772,14 +772,13 @@ describe('Normal Query - No Parameter', () => {
 				staleTimeStamp: mockDate.getTime(),
 				enabled: true
 			},
-			// Force-invalidating (resets and reloads data)
+			// Force-invalidating (forgets all cached state and reloads)
 			{
 				data: undefined,
 				error: undefined,
 				loading: true,
-				loadedTimeStamp: mockDate.getTime(),
-				// invalidating sets the stale time to now - 1
-				staleTimeStamp: mockDate.getTime() + 1000 - 1,
+				loadedTimeStamp: undefined,
+				staleTimeStamp: undefined,
 				enabled: true
 			},
 			// After reload

--- a/tests/createQuery/noParam.svelte.test.ts
+++ b/tests/createQuery/noParam.svelte.test.ts
@@ -275,6 +275,49 @@ describe('Normal Query - No Parameter', () => {
 		]);
 	});
 
+	test('Loaded null data does not fall back to initialData', async () => {
+		vi.useFakeTimers();
+		const mockDate = new Date(2025, 5, 11, 12, 0, 0);
+		vi.setSystemTime(mockDate);
+
+		const states = $state({ value: [] });
+		const rendered = render(NoParam, {
+			props: {
+				states,
+				key: ['null-data-test'],
+				loadingFn: async () => ({ success: true, data: null }),
+				queryOptions: {
+					initialData: 'initial data'
+				}
+			}
+		});
+
+		await waitFor(() => {
+			expect(rendered.queryByText('Loading: false')).toBeInTheDocument();
+		});
+
+		expect(states.value).toEqual([
+			// Initial state (initialData is used before the first load)
+			{
+				data: 'initial data',
+				error: undefined,
+				loading: true,
+				loadedTimeStamp: undefined,
+				staleTimeStamp: undefined,
+				enabled: true
+			},
+			// After loading (null is the loaded data, not initialData)
+			{
+				data: null,
+				error: undefined,
+				loading: false,
+				loadedTimeStamp: mockDate.getTime(),
+				staleTimeStamp: mockDate.getTime(),
+				enabled: true
+			}
+		]);
+	});
+
 	test('Reloads data when the query is mounted', async () => {
 		vi.useFakeTimers();
 		const mockDate = new Date(2025, 5, 11, 12, 0, 0);

--- a/tests/createSequentialQuery/noParams.svelte.test.ts
+++ b/tests/createSequentialQuery/noParams.svelte.test.ts
@@ -536,6 +536,175 @@ describe('Sequential Query - No Parameter', () => {
 		]);
 	});
 
+	test('Concurrent loadMore only loads one page', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(2025, 5, 11, 12, 0, 0));
+
+		type Page = { success: true; data: number[]; cursor: number };
+		const resolvers: ((page: Page) => void)[] = [];
+		const mockLoadingFn = vi.fn(
+			(_: void, cursor: number = 0) =>
+				new Promise<Page>((resolve) => {
+					resolvers.push(() =>
+						resolve({
+							success: true,
+							data: [cursor],
+							cursor: cursor + 10
+						})
+					);
+				})
+		);
+
+		const states = $state({ value: [] });
+		const rendered = render(NoParam, {
+			props: {
+				states,
+				key: ['concurrent-load-more-test'],
+				loadingFn: mockLoadingFn
+			}
+		});
+
+		// Resolve the initial load
+		await waitFor(() => expect(resolvers.length).toBe(1));
+		resolvers[0]({ success: true, data: [0], cursor: 10 });
+		await waitFor(() => {
+			expect(rendered.queryByText('Data: [[0]]')).toBeInTheDocument();
+		});
+
+		// Click "Load More" twice while no load has resolved yet
+		rendered.queryByText('Load More')?.click();
+		rendered.queryByText('Load More')?.click();
+		await vi.advanceTimersByTimeAsync(100);
+
+		// Only one additional load was started
+		expect(mockLoadingFn).toHaveBeenCalledTimes(2);
+
+		resolvers[1]({ success: true, data: [10], cursor: 20 });
+		await waitFor(() => {
+			expect(rendered.queryByText('Data: [[0],[10]]')).toBeInTheDocument();
+		});
+	});
+
+	test('Failed reload of all pages keeps the cursor consistent', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(2025, 5, 11, 12, 0, 0));
+
+		let callCount = 0;
+		const states = $state({ value: [] });
+		const rendered = render(NoParam, {
+			props: {
+				states,
+				key: ['failed-reload-cursor-test'],
+				loadingFn: async (_, cursor = 0) => {
+					callCount++;
+					// The 4th call is the second page of the invalidation reload
+					if (callCount === 4) {
+						return { success: false, error: 'reload failed' };
+					}
+					return { success: true, data: [cursor], cursor: cursor + 10 };
+				}
+			}
+		});
+
+		// Load two pages (cursor is now 20)
+		await waitFor(() => {
+			expect(rendered.queryByText('Data: [[0]]')).toBeInTheDocument();
+		});
+		rendered.queryByText('Load More')?.click();
+		await waitFor(() => {
+			expect(rendered.queryByText('Data: [[0],[10]]')).toBeInTheDocument();
+		});
+
+		// Invalidate: the reload of page 2 fails, previous data is kept
+		vi.advanceTimersByTime(1000);
+		invalidateQueries(['failed-reload-cursor-test']);
+		await waitFor(() => {
+			expect(rendered.queryByText('Error: reload failed')).toBeInTheDocument();
+			expect(rendered.queryByText('Data: [[0],[10]]')).toBeInTheDocument();
+		});
+
+		// Loading more must continue after the kept pages (cursor 20),
+		// not from the mid-reload cursor
+		rendered.queryByText('Load More')?.click();
+		await waitFor(() => {
+			expect(rendered.queryByText('Data: [[0],[10],[20]]')).toBeInTheDocument();
+		});
+	});
+
+	test('Reloading stops early when the data has shrunk', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(2025, 5, 11, 12, 0, 0));
+
+		let callCount = 0;
+		const states = $state({ value: [] });
+		const rendered = render(NoParam, {
+			props: {
+				states,
+				key: ['shrunken-reload-test'],
+				loadingFn: async (_, cursor = 0) => {
+					callCount++;
+					// First two calls: two pages exist
+					if (callCount <= 2) {
+						return { success: true, data: [cursor], cursor: cursor + 10 };
+					}
+					// After that, only a single page without more data
+					return { success: true, data: [99], cursor: undefined };
+				}
+			}
+		});
+
+		// Load two pages
+		await waitFor(() => {
+			expect(rendered.queryByText('Data: [[0]]')).toBeInTheDocument();
+		});
+		rendered.queryByText('Load More')?.click();
+		await waitFor(() => {
+			expect(rendered.queryByText('Data: [[0],[10]]')).toBeInTheDocument();
+		});
+
+		// Invalidate: the first reloaded page has no more data, so the
+		// second page is not fetched again (and not duplicated)
+		vi.advanceTimersByTime(1000);
+		invalidateQueries(['shrunken-reload-test']);
+		await waitFor(() => {
+			expect(rendered.queryByText('Data: [[99]]')).toBeInTheDocument();
+			expect(rendered.queryByText('Has More: No')).toBeInTheDocument();
+		});
+
+		expect(callCount).toBe(3);
+	});
+
+	test('loadMore does nothing when there is no more data', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(2025, 5, 11, 12, 0, 0));
+
+		const mockLoadingFn = vi.fn(async () => ({
+			success: true as const,
+			data: 'only page',
+			cursor: undefined
+		}));
+
+		const states = $state({ value: [] });
+		const rendered = render(NoParam, {
+			props: {
+				states,
+				key: ['load-more-exhausted-test'],
+				loadingFn: mockLoadingFn
+			}
+		});
+
+		await waitFor(() => {
+			expect(rendered.queryByText('Has More: No')).toBeInTheDocument();
+		});
+		expect(mockLoadingFn).toHaveBeenCalledTimes(1);
+
+		// Load More must not trigger another load
+		rendered.queryByText('Load More')?.click();
+		await vi.advanceTimersByTimeAsync(100);
+
+		expect(mockLoadingFn).toHaveBeenCalledTimes(1);
+	});
+
 	test('Reloads data from all pages when invalidated', async () => {
 		vi.useFakeTimers();
 		const mockDate = new Date(2025, 5, 11, 12, 0, 0);

--- a/tests/invalidation/invalidation.svelte.test.ts
+++ b/tests/invalidation/invalidation.svelte.test.ts
@@ -5,6 +5,10 @@ import {
 	invalidateQueries,
 	updateQueryData
 } from '../../src/lib/svelte-tiny-query/invalidate.svelte';
+import {
+	errorByKey,
+	loadingByKey
+} from '../../src/lib/svelte-tiny-query/cache.svelte';
 import NoParam from '../createQuery/NoParam.svelte';
 
 describe('invalidateQueries - prefix matching', () => {
@@ -127,6 +131,40 @@ describe('invalidateQueries - prefix matching', () => {
 		});
 
 		expect(parentCallCount).toBe(2);
+	});
+});
+
+describe('invalidateQueries - force', () => {
+	test('clears the cached error of a query that never had data', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(2025, 5, 11, 12, 0, 0));
+
+		const states = $state({ value: [] });
+		const rendered = render(NoParam, {
+			props: {
+				states,
+				key: ['force-error-clear-test'],
+				loadingFn: async () => ({ success: false, error: 'oopsie' })
+			}
+		});
+
+		await waitFor(() => {
+			expect(rendered.queryByText('Error: oopsie')).toBeInTheDocument();
+		});
+
+		expect(errorByKey['force-error-clear-test']).toBe('oopsie');
+		expect(loadingByKey['force-error-clear-test']).toBe(false);
+
+		// Unmount, so that force-invalidation does not trigger a reload
+		// (which would reset the error anyway)
+		rendered.unmount();
+
+		invalidateQueries(['force-error-clear-test'], { force: true });
+
+		// The error and loading entries are gone, even though the query
+		// never had any data cached
+		expect(errorByKey['force-error-clear-test']).toBeUndefined();
+		expect(loadingByKey['force-error-clear-test']).toBeUndefined();
 	});
 });
 


### PR DESCRIPTION
Bug fixes and one new feature, based on a code assessment of the v2 release. Version bumped to 2.1.0.

## Bug Fixes

- **`null` data no longer falls back to `initialData`** — the `data` getters checked with `??`, so a load that legitimately returned `null` was masked. They now check key presence in the cache.
- **Force-invalidation fully resets queries without data** — it only iterated the data record, so queries that had only ever produced an error kept their cached error and loading state. It now clears every state record for matching keys, including the loaded/stale timestamps (a force-invalidated query is completely forgotten).
- **`reload` and `loadMore` are no-ops while disabled** — previously only when the query had never been enabled; once a loader existed from an earlier enabled phase, `reload` would still trigger a load.
- **Sequential query races and cursor consistency** — loads for the same key never run concurrently anymore (`force` only bypasses staleness), so a double `loadMore` cannot lose or duplicate a page. Cursor and `hasMore` are only written after a fully successful load, so a reload-all that fails midway stays consistent with the kept pages. Reloading all pages stops early when a page returns no cursor (shrunken data no longer re-appends the first page), and `loadMore` does nothing when `hasMore` is false.

## New Feature

- **Opt-in `gcTime` cache eviction** — new option on `createQuery` and `createSequentialQuery`. A query's cached state (including the loader closure and its captured param) is evicted `gcTime` after the query is both **unused** (not part of any mounted component) and **stale**. Fresh data is never collected — with `staleTime: Infinity` the cache is kept forever. Becoming active again cancels a pending eviction. Without `gcTime`, behavior is unchanged (cache is kept for the lifetime of the app).

## Docs & Tests

- README documents `gcTime` and the clarified `enabled`/`loadMore` semantics; roadmap updated.
- Every fix has a regression test; the suite grew from 82 to 95 tests.