### PR TITLE
Add persister option to createQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Check out the [**interactive docs**](https://kidesia.github.io/svelte-tiny-query
 - 🔁 Retries with exponential backoff
 - 🚫 Cancellation of in-flight loads
 - 📜 Sequential queries (pagination, load-more)
+- 📦 Per-query persistence (localStorage & co)
 - 🐍 Written in TypeScript
 
 ## Usage
@@ -126,6 +127,7 @@ function createQuery<TError, TParam, TData>(
     staleTime?: number;
     gcTime?: number;
     retry?: number;
+    persister?: QueryPersister<TData>;
   }
 ): (
   param?: TParam | (() => TParam),
@@ -159,11 +161,27 @@ The loading function also receives an `AbortSignal`, which is aborted when the l
 
 - **staleTime**: How long (in milliseconds) the loaded data stays fresh. A query whose data is fresh is not automatically reloaded when it is used again. Defaults to `0` (using a query always reloads it). Set it to `Infinity` to never reload automatically.
 
-- **initialData**: Used as the value of `data` before the query has first loaded (instead of `undefined`). When provided, the type of `query.data` is narrowed from `TData | undefined` to `TData`. Can be used to implement persisted queries.
+- **initialData**: Used as the value of `data` before the query has first loaded (instead of `undefined`). When provided, the type of `query.data` is narrowed from `TData | undefined` to `TData`. Useful for precomputed data — for persisted data, see `persister` below.
 
 - **gcTime**: Enables garbage collection for the query: its cached state is evicted `gcTime` milliseconds after the query is both **unused** (not part of any mounted component) and **stale**. Fresh data is never collected — with `staleTime: Infinity`, the cache is kept forever, so set that deliberately. Using the query again cancels a pending eviction. If `gcTime` is not set, cached data is kept for the lifetime of the app. You rarely need this — set it on queries whose parameter space is unbounded (search input, per-item detail views), where distinct cache keys accumulate over a session.
 
 - **retry**: How many times a failed load is retried before the error is stored. Defaults to `0` (no retries). Retries use exponential backoff (1s, 2s, 4s, … capped at 30s). Retrying is invisible from the outside: the query simply stays in its loading state, and only the final error is exposed.
+
+- **persister**: Persists the query's data outside the in-memory cache, e.g. in `localStorage`. `get(key)` restores the data of a query that has none cached yet: the restored data is shown right away, but does not prevent the load (restored data always counts as stale). `set(key, data)` is called with the data of every successful load, and `remove(key)` when the query is invalidated with `force: true`. All three functions receive the cache key as an array of strings and may be sync or async. Serialization is up to the persister, and its failures are logged to the console without ever breaking the query. Note that `updateQueryData` does not persist — only actual loads do.
+
+  ```typescript
+  const useMemeIdea = createQuery(['meme-idea'], loadMemeIdea, {
+    persister: {
+      get: (key) => {
+        const raw = localStorage.getItem(key.join('/'));
+        return raw ? JSON.parse(raw) : undefined;
+      },
+      set: (key, data) =>
+        localStorage.setItem(key.join('/'), JSON.stringify(data)),
+      remove: (key) => localStorage.removeItem(key.join('/'))
+    }
+  });
+  ```
 
 #### Return: The Query Function
 
@@ -344,9 +362,6 @@ Use `$effect`, `setInterval` (or `addEventListener`) and `reload` to achieve thi
 
 **Dependent Queries**<br />
 Use the `enabled` option to only load a query when its prerequisites are ready.
-
-**Persisted Queries**<br />
-Use `initialData` to inject persisted data into the query.
 
 **Mutations**<br />
 Mutations can just be normal functions. Use `invalidateQueries` (or the experimental `updateQueryData`) to update queries after a mutation.

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -5,7 +5,7 @@ import {
 } from './svelte-tiny-query/cache.svelte';
 import { KEY_SEPARATOR } from './svelte-tiny-query/utils.js';
 
-export type { QueryParam } from './svelte-tiny-query/utils.js';
+export type { QueryParam, QueryPersister } from './svelte-tiny-query/utils.js';
 export * from './svelte-tiny-query/query.svelte';
 export * from './svelte-tiny-query/sequential.svelte';
 export * from './svelte-tiny-query/invalidate.svelte';

--- a/src/lib/svelte-tiny-query/cache.svelte.ts
+++ b/src/lib/svelte-tiny-query/cache.svelte.ts
@@ -1,4 +1,4 @@
-import type { QueryLoadMode } from './utils.js';
+import type { QueryLoadMode, QueryPersister } from './utils.js';
 
 // Non-Reactive State
 
@@ -6,6 +6,10 @@ export const queryLoaderByKey = {} as Record<
 	string,
 	(mode?: QueryLoadMode) => Promise<void>
 >;
+
+export const persisterByKey = {} as Record<string, QueryPersister<unknown>>;
+
+export const restoreStartedByKey = {} as Record<string, boolean>;
 
 export const evictionTimerByKey = {} as Record<
 	string,

--- a/src/lib/svelte-tiny-query/invalidate.svelte.ts
+++ b/src/lib/svelte-tiny-query/invalidate.svelte.ts
@@ -8,9 +8,11 @@ import {
 	activeQueryCounts,
 	abortControllerByKey,
 	hasMoreByKey,
-	cursorByKey
+	cursorByKey,
+	persisterByKey,
+	restoreStartedByKey
 } from './cache.svelte';
-import { cancelLoad } from './queryHelpers.svelte';
+import { cancelLoad, removePersistedData } from './queryHelpers.svelte';
 import { KEY_SEPARATOR } from './utils.js';
 
 /**
@@ -53,6 +55,20 @@ export function invalidateQueries(
 	// is cleared separately, so that queries which only ever produced an
 	// error (and thus have no data entry) are also fully reset.
 	if (options?.force) {
+		// Also remove the persisted data of matching queries (only reaches
+		// queries whose persister was registered this session). Clearing the
+		// restore guards discards in-flight restores as outdated.
+		Object.entries(persisterByKey).forEach(([key, persister]) => {
+			if (matches(key)) {
+				removePersistedData(key, persister);
+			}
+		});
+		Object.keys(restoreStartedByKey).forEach((key) => {
+			if (matches(key)) {
+				delete restoreStartedByKey[key];
+			}
+		});
+
 		const records = [
 			loadingByKey,
 			dataByKey,

--- a/src/lib/svelte-tiny-query/query.svelte.ts
+++ b/src/lib/svelte-tiny-query/query.svelte.ts
@@ -1,11 +1,17 @@
 import { untrack } from 'svelte';
 
 import type { LoadResult } from './loadHelpers.js';
-import { generateCacheKey, normalizeParam, type QueryParam } from './utils.js';
+import {
+	generateCacheKey,
+	normalizeParam,
+	type QueryParam,
+	type QueryPersister
+} from './utils.js';
 import {
 	warnIfTracking,
 	trackActiveQueriesCount,
-	withLoading
+	withLoading,
+	restorePersistedData
 } from './queryHelpers.svelte';
 import {
 	queryLoaderByKey,
@@ -13,7 +19,8 @@ import {
 	dataByKey,
 	errorByKey,
 	loadedTimeStampByKey,
-	staleTimeStampByKey
+	staleTimeStampByKey,
+	persisterByKey
 } from './cache.svelte';
 
 /**
@@ -95,6 +102,14 @@ export function createQuery<
 		 * Defaults to 0 (no retries).
 		 */
 		retry?: number;
+		/**
+		 * Persists the query data outside the in-memory cache (e.g. in
+		 * localStorage). `get` restores the data of a query that has none
+		 * cached yet (shown while the first load runs, without preventing
+		 * it), `set` is called with the data of every successful load, and
+		 * `remove` when the query is invalidated with `force: true`.
+		 */
+		persister?: QueryPersister<TData>;
 	}
 ): (
 	param?: TParam | (() => TParam),
@@ -149,6 +164,14 @@ export function createQuery<
 		 * Defaults to 0 (no retries).
 		 */
 		retry?: number;
+		/**
+		 * Persists the query data outside the in-memory cache (e.g. in
+		 * localStorage). `get` restores the data of a query that has none
+		 * cached yet (shown while the first load runs, without preventing
+		 * it), `set` is called with the data of every successful load, and
+		 * `remove` when the query is invalidated with `force: true`.
+		 */
+		persister?: QueryPersister<TData>;
 	}
 ): (
 	param?: TParam | (() => TParam),
@@ -166,6 +189,7 @@ export function createQuery<TData, TError, TParam extends QueryParam = void>(
 		staleTime?: number;
 		gcTime?: number;
 		retry?: number;
+		persister?: QueryPersister<TData>;
 	}
 ): (
 	param?: TParam | (() => TParam),
@@ -200,6 +224,14 @@ export function createQuery<TData, TError, TParam extends QueryParam = void>(
 			// Set the new cache key in the internal state
 			internalState.currentKey = cacheKey;
 
+			// Register the persister and restore persisted data (if any).
+			// Untracked, because the restore reads the reactive data records
+			if (options?.persister) {
+				const persister = options.persister as QueryPersister<unknown>;
+				persisterByKey[cacheKey] = persister;
+				untrack(() => restorePersistedData(cacheKey, persister));
+			}
+
 			if (!queryLoaderByKey[cacheKey]) {
 				// Create and store the query loader if it doesn't exist
 				queryLoaderByKey[cacheKey] = async () => {
@@ -211,7 +243,8 @@ export function createQuery<TData, TError, TParam extends QueryParam = void>(
 							},
 							options?.staleTime,
 							false,
-							options?.retry
+							options?.retry,
+							options?.persister
 						);
 					});
 				};

--- a/src/lib/svelte-tiny-query/queryHelpers.svelte.ts
+++ b/src/lib/svelte-tiny-query/queryHelpers.svelte.ts
@@ -10,10 +10,16 @@ import {
 	evictionTimerByKey,
 	abortControllerByKey,
 	cursorByKey,
-	hasMoreByKey
+	hasMoreByKey,
+	persisterByKey,
+	restoreStartedByKey
 } from './cache.svelte';
 import type { LoadResult } from './loadHelpers.js';
-import { generateCacheKey } from './utils.js';
+import {
+	generateCacheKey,
+	KEY_SEPARATOR,
+	type QueryPersister
+} from './utils.js';
 
 export function warnIfTracking(fnName: string, key: string) {
 	if ($effect.tracking()) {
@@ -110,6 +116,74 @@ function evictIfUnusedAndStale(cacheKey: string, gcTime: number) {
 	delete staleTimeStampByKey[cacheKey];
 	delete cursorByKey[cacheKey];
 	delete hasMoreByKey[cacheKey];
+
+	// The persisted data itself is kept: clearing the restore guard makes
+	// the next use of the query restore it from the persister again
+	delete persisterByKey[cacheKey];
+	delete restoreStartedByKey[cacheKey];
+}
+
+// A failing persister must never break the query itself, so all persister
+// calls are wrapped and failures are only reported to the console
+function safePersist(
+	cacheKey: string,
+	operation: 'get' | 'set' | 'remove',
+	fn: () => unknown
+) {
+	const onError = (error: unknown) =>
+		console.error(
+			`svelte-tiny-query (${cacheKey}): the persister's ${operation} function failed.`,
+			error
+		);
+	try {
+		Promise.resolve(fn()).catch(onError);
+	} catch (error) {
+		onError(error);
+	}
+}
+
+/**
+ * Restores persisted data for a query that has no cached data yet
+ * (fire-and-forget). Restored data acts like initial data: it is shown
+ * right away, but the query still counts as never loaded, so the normal
+ * load is not skipped and its data is never overwritten.
+ */
+export function restorePersistedData(
+	cacheKey: string,
+	persister: QueryPersister<unknown>
+) {
+	if (restoreStartedByKey[cacheKey] || cacheKey in dataByKey) return;
+	restoreStartedByKey[cacheKey] = true;
+
+	safePersist(cacheKey, 'get', () =>
+		Promise.resolve(persister.get(cacheKey.split(KEY_SEPARATOR))).then(
+			(restored) => {
+				// Undefined means no persisted data. A load that finished in the
+				// meantime always wins, and a cleared guard (eviction or forced
+				// invalidation) means the restored data is outdated by now
+				if (
+					restored === undefined ||
+					!restoreStartedByKey[cacheKey] ||
+					cacheKey in dataByKey
+				) {
+					return;
+				}
+				dataByKey[cacheKey] = restored;
+			}
+		)
+	);
+}
+
+/**
+ * Removes the persisted data of a query (fire-and-forget).
+ */
+export function removePersistedData(
+	cacheKey: string,
+	persister: QueryPersister<unknown>
+) {
+	safePersist(cacheKey, 'remove', () =>
+		persister.remove(cacheKey.split(KEY_SEPARATOR))
+	);
 }
 
 export async function withLoading<TData, TError>(
@@ -117,7 +191,8 @@ export async function withLoading<TData, TError>(
 	loadFn: (signal: AbortSignal) => Promise<LoadResult<TData, TError>>,
 	staleTime = 0,
 	force = false,
-	retry = 0
+	retry = 0,
+	persister?: QueryPersister<TData>
 ) {
 	// Skip if this query is already loading (loads are never concurrent per
 	// key, not even when forced) or if it still has fresh data (unless forced)
@@ -161,6 +236,13 @@ export async function withLoading<TData, TError>(
 			dataByKey[key] = loadResult.data;
 			loadedTimeStampByKey[key] = Date.now();
 			staleTimeStampByKey[key] = Date.now() + staleTime;
+
+			if (persister) {
+				const { data } = loadResult;
+				safePersist(key, 'set', () =>
+					persister.set(key.split(KEY_SEPARATOR), data)
+				);
+			}
 		} else {
 			errorByKey[key] = loadResult.error;
 		}

--- a/src/lib/svelte-tiny-query/utils.ts
+++ b/src/lib/svelte-tiny-query/utils.ts
@@ -6,6 +6,21 @@ export const KEY_SEPARATOR = '\x1F';
 
 export type QueryLoadMode = 'more' | 'reload' | 'load';
 
+/**
+ * Persists query data outside the in-memory cache (e.g. in localStorage
+ * or IndexedDB). All functions receive the cache key of the query as an
+ * array of segments and may be synchronous or asynchronous. Serialization
+ * of the data is up to the persister.
+ */
+export type QueryPersister<TData> = {
+	/** Reads the persisted data for a key (`undefined` means no data). */
+	get: (key: string[]) => TData | undefined | Promise<TData | undefined>;
+	/** Persists the data of a successful load for a key. */
+	set: (key: string[], data: TData) => void | Promise<void>;
+	/** Removes the persisted data for a key. */
+	remove: (key: string[]) => void | Promise<void>;
+};
+
 /** Values that are valid as query parameters (i.e. serializable for cache keys). */
 export type QueryParam =
 	| void

--- a/src/routes/ApiReference.svelte
+++ b/src/routes/ApiReference.svelte
@@ -19,6 +19,11 @@
   | string | number | boolean | bigint | symbol
   | null | undefined | Date | RegExp
   | QueryParam[] | { [key: string]: QueryParam };`,
+		QueryPersister: `type QueryPersister<TData> = {
+  get: (key: string[]) => TData | undefined | Promise<TData | undefined>;
+  set: (key: string[], data: TData) => void | Promise<void>;
+  remove: (key: string[]) => void | Promise<void>;
+};`,
 		SequentialLoadResult: `type SequentialLoadResult<TData, TCursor, TError> =
   | { success: true; data: TData; cursor: TCursor | undefined }
   | { success: false; error: TError };`,
@@ -40,7 +45,8 @@
 	const createQueryType = `function createQuery<TError, TParam extends QueryParam, TData>(
   key: string[] | ((param: TParam) => string[]),
   loadFn: (param: TParam, signal: AbortSignal) => Promise<LoadResult<TData, TError>>,
-  options?: { initialData?: TData; staleTime?: number; gcTime?: number; retry?: number }
+  options?: { initialData?: TData; staleTime?: number; gcTime?: number; retry?: number;
+    persister?: QueryPersister<TData> }
 ): (param?: TParam | (() => TParam), options?: QueryInvokeOptions) => QueryState<TData, TError>;`;
 
 	const sequentialType = `function createSequentialQuery<TError, TParam extends QueryParam, TData, TCursor>(
@@ -268,6 +274,21 @@ query.error; // string | undefined`;
 					Backoff is exponential: 1s, 2s, 4s, … capped at 30s. Retrying is
 					invisible — the query stays in its loading state and only the final
 					result lands.
+				</td>
+			</tr>
+			<tr>
+				<td>persister</td>
+				<td>undefined</td>
+				<td>
+					Persists the query's data outside the in-memory cache, e.g. in
+					<code>localStorage</code>. <code>get(key)</code> restores the data of
+					a query that has none cached yet — it is shown right away but counts
+					as stale, so the load still runs. <code>set(key, data)</code> is
+					called with the data of every successful load, and
+					<code>remove(key)</code> when the query is invalidated with
+					<code>force: true</code>. All functions receive the cache key as an
+					array of strings and may be sync or async; serialization is up to the
+					persister.
 				</td>
 			</tr>
 		</tbody>

--- a/tests/createQuery/NoParam.svelte
+++ b/tests/createQuery/NoParam.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 	import { untrack } from 'svelte';
-	import { createQuery, type LoadResult } from '../../src/lib/index.ts';
+	import {
+		createQuery,
+		type LoadResult,
+		type QueryPersister
+	} from '../../src/lib/index.ts';
 	import { captureState } from '../testHelpers.ts';
 
 	let {
@@ -22,6 +26,7 @@
 			initialData?: unknown;
 			gcTime?: number;
 			retry?: number;
+			persister?: QueryPersister<unknown>;
 		};
 	} = $props();
 

--- a/tests/createQuery/persister.svelte.test.ts
+++ b/tests/createQuery/persister.svelte.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, test, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/svelte/svelte5';
+
+import {
+	invalidateQueries,
+	type LoadResult,
+	type QueryPersister
+} from '../../src/lib/index.ts';
+import { dataByKey } from '../../src/lib/svelte-tiny-query/cache.svelte';
+import NoParam from './NoParam.svelte';
+
+// A synchronous in-memory persister, so tests can inspect the storage
+function makePersister(initial?: Record<string, unknown>) {
+	const storage = new Map<string, unknown>(Object.entries(initial ?? {}));
+	const persister = {
+		get: vi.fn((key: string[]) => storage.get(key.join('/'))),
+		set: vi.fn((key: string[], data: unknown) => {
+			storage.set(key.join('/'), data);
+		}),
+		remove: vi.fn((key: string[]) => {
+			storage.delete(key.join('/'));
+		})
+	} satisfies QueryPersister<unknown>;
+	return { storage, persister };
+}
+
+describe('Normal Query - persister Option', () => {
+	test('Shows restored data while loading, then persists the fresh data', async () => {
+		const { storage, persister } = makePersister({
+			'persister-restore-test': 'persisted'
+		});
+
+		let resolveLoad: (result: LoadResult<unknown, unknown>) => void;
+		const mockLoadingFn = vi.fn(
+			() =>
+				new Promise<LoadResult<unknown, unknown>>((resolve) => {
+					resolveLoad = resolve;
+				})
+		);
+
+		const states = $state({ value: [] });
+		const rendered = render(NoParam, {
+			props: {
+				states,
+				key: ['persister-restore-test'],
+				loadingFn: mockLoadingFn,
+				queryOptions: { persister }
+			}
+		});
+
+		// The restored data is shown while the query is still loading
+		await waitFor(() => {
+			expect(rendered.queryByText('Data: persisted')).toBeInTheDocument();
+		});
+		expect(rendered.queryByText('Loading: true')).toBeInTheDocument();
+		expect(persister.get).toHaveBeenCalledWith(['persister-restore-test']);
+
+		// The load is not skipped and its data replaces the restored data
+		resolveLoad!({ success: true, data: 'fresh' });
+		await waitFor(() => {
+			expect(rendered.queryByText('Data: fresh')).toBeInTheDocument();
+		});
+		expect(mockLoadingFn).toHaveBeenCalledTimes(1);
+
+		// The fresh data was persisted
+		expect(persister.set).toHaveBeenCalledWith(
+			['persister-restore-test'],
+			'fresh'
+		);
+		expect(storage.get('persister-restore-test')).toBe('fresh');
+
+		// Remounting restores nothing (the data is still cached in memory)
+		rendered.unmount();
+		const states2 = $state({ value: [] });
+		const rendered2 = render(NoParam, {
+			props: {
+				states: states2,
+				key: ['persister-restore-test'],
+				loadingFn: mockLoadingFn,
+				queryOptions: { persister }
+			}
+		});
+		await waitFor(() => {
+			expect(rendered2.queryByText('Data: fresh')).toBeInTheDocument();
+		});
+		expect(persister.get).toHaveBeenCalledTimes(1);
+
+		rendered2.unmount();
+	});
+
+	test('A persister without data leaves the query untouched', async () => {
+		const { persister } = makePersister();
+
+		const states = $state({ value: [] });
+		const rendered = render(NoParam, {
+			props: {
+				states,
+				key: ['persister-miss-test'],
+				loadingFn: async () => ({ success: true as const, data: 'fresh' }),
+				queryOptions: { persister, initialData: 'initial' }
+			}
+		});
+
+		await waitFor(() => {
+			expect(rendered.queryByText('Data: fresh')).toBeInTheDocument();
+		});
+
+		// The miss never stored anything, so initialData applied while loading
+		const shownData = states.value.map(
+			(state) => (state as { data: unknown }).data
+		);
+		expect(shownData).not.toContain(undefined);
+		expect(shownData[0]).toBe('initial');
+
+		rendered.unmount();
+	});
+
+	test('A slow restore never overwrites already loaded data', async () => {
+		const { persister } = makePersister();
+		let resolveGet: (value: unknown) => void;
+		persister.get.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					resolveGet = resolve;
+				})
+		);
+
+		const states = $state({ value: [] });
+		const rendered = render(NoParam, {
+			props: {
+				states,
+				key: ['persister-slow-get-test'],
+				loadingFn: async () => ({ success: true as const, data: 'fresh' }),
+				queryOptions: { persister }
+			}
+		});
+
+		await waitFor(() => {
+			expect(rendered.queryByText('Data: fresh')).toBeInTheDocument();
+		});
+
+		// The restore resolves after the load has finished — it is discarded
+		resolveGet!('persisted');
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(dataByKey['persister-slow-get-test']).toBe('fresh');
+
+		rendered.unmount();
+	});
+
+	test('Force invalidation removes the persisted data', async () => {
+		const { storage, persister } = makePersister();
+
+		const states = $state({ value: [] });
+		const rendered = render(NoParam, {
+			props: {
+				states,
+				key: ['persister-remove-test'],
+				loadingFn: async () => ({ success: true as const, data: 'fresh' }),
+				queryOptions: { persister }
+			}
+		});
+
+		await waitFor(() => {
+			expect(rendered.queryByText('Data: fresh')).toBeInTheDocument();
+		});
+		expect(storage.get('persister-remove-test')).toBe('fresh');
+
+		// A plain invalidation keeps the persisted data (and re-persists on
+		// the reload that it triggers)
+		invalidateQueries(['persister-remove-test']);
+		await waitFor(() => {
+			expect(rendered.queryByText('Loading: false')).toBeInTheDocument();
+		});
+		expect(persister.remove).not.toHaveBeenCalled();
+
+		// A forced invalidation removes the persisted data
+		invalidateQueries(['persister-remove-test'], { force: true });
+		expect(persister.remove).toHaveBeenCalledWith(['persister-remove-test']);
+		expect(storage.has('persister-remove-test')).toBe(false);
+
+		rendered.unmount();
+	});
+
+	test('Persisted data is restored again after gc eviction', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(2025, 5, 11, 12, 0, 0));
+
+		const { storage, persister } = makePersister();
+
+		const states = $state({ value: [] });
+		const rendered = render(NoParam, {
+			props: {
+				states,
+				key: ['persister-gc-test'],
+				loadingFn: async () => ({ success: true as const, data: 'fresh' }),
+				queryOptions: { persister, gcTime: 5000 }
+			}
+		});
+
+		await waitFor(() => {
+			expect(rendered.queryByText('Data: fresh')).toBeInTheDocument();
+		});
+
+		// After eviction, the memory cache is gone but the storage is not
+		rendered.unmount();
+		vi.advanceTimersByTime(5000);
+		expect('persister-gc-test' in dataByKey).toBe(false);
+		expect(storage.get('persister-gc-test')).toBe('fresh');
+
+		// Using the query again restores the persisted data while it reloads
+		let resolveLoad: (result: LoadResult<unknown, unknown>) => void;
+		const states2 = $state({ value: [] });
+		const rendered2 = render(NoParam, {
+			props: {
+				states: states2,
+				key: ['persister-gc-test'],
+				loadingFn: () =>
+					new Promise((resolve) => {
+						resolveLoad = resolve;
+					}),
+				queryOptions: { persister, gcTime: 5000 }
+			}
+		});
+
+		await waitFor(() => {
+			expect(rendered2.queryByText('Data: fresh')).toBeInTheDocument();
+		});
+		expect(rendered2.queryByText('Loading: true')).toBeInTheDocument();
+		expect(persister.get).toHaveBeenCalledTimes(2);
+
+		resolveLoad!({ success: true, data: 'fresher' });
+		await waitFor(() => {
+			expect(rendered2.queryByText('Data: fresher')).toBeInTheDocument();
+		});
+
+		rendered2.unmount();
+		vi.useRealTimers();
+	});
+
+	test('A failing persister does not break the query', async () => {
+		const consoleError = vi
+			.spyOn(console, 'error')
+			.mockImplementation(() => {});
+
+		const persister: QueryPersister<unknown> = {
+			get: () => Promise.reject(new Error('get failed')),
+			set: () => {
+				throw new Error('set failed');
+			},
+			remove: () => Promise.reject(new Error('remove failed'))
+		};
+
+		const states = $state({ value: [] });
+		const rendered = render(NoParam, {
+			props: {
+				states,
+				key: ['persister-failing-test'],
+				loadingFn: async () => ({ success: true as const, data: 'fresh' }),
+				queryOptions: { persister }
+			}
+		});
+
+		// The query loads normally despite get and set failing
+		await waitFor(() => {
+			expect(rendered.queryByText('Data: fresh')).toBeInTheDocument();
+		});
+		expect(rendered.queryByText('Error:')).toBeInTheDocument();
+
+		invalidateQueries(['persister-failing-test'], { force: true });
+
+		// All failures were reported: get and set on the initial load,
+		// remove on the invalidation, and set again on the forced reload
+		await waitFor(() => {
+			expect(consoleError).toHaveBeenCalledTimes(4);
+		});
+
+		rendered.unmount();
+		consoleError.mockRestore();
+	});
+});


### PR DESCRIPTION
This PR adds a per-query persistence option to `createQuery`: a `persister` provides the initial value of the query data and stores the data of every successful load, so query data can survive page reloads (e.g. in `localStorage` or IndexedDB).

### The persister option

New `persister` option on `createQuery`: an object of shape `{ get, set, remove }` (exported as `QueryPersister<TData>`). All three functions receive the cache key as an array of strings — matching how `invalidateQueries`, `updateQueryData` and `queryInfos` speak about keys — and may be synchronous or asynchronous, so both `localStorage` wrappers and IndexedDB work. The persister deals in `TData` directly; serialization is entirely up to it. The name follows TanStack Query, which calls its (experimental) per-query equivalent `persister`.

### Restore semantics

`get` is called once per cache key when the query first runs without cached data. A restored value acts like initial data: it is shown right away, but it is stored without timestamps, so the query still counts as never loaded and the normal load proceeds (stale-while-revalidate). A restore never overwrites loaded data — a slow asynchronous `get` that resolves after the load has finished is discarded. Restored data is deliberately always considered stale: `staleTime` never suppresses a load based on what is on disk.

This composes with `gcTime`: eviction clears the in-memory cache but keeps the persisted copy and resets the restore guard, so the next use of the query restores instantly from the persister while fetching fresh data.

### Persisting and removing

`set` is called with the data of every successful load (fire-and-forget). `remove` is called when a query is invalidated with `force: true` — forced invalidation already means "throw this data away now", and that now extends to the persisted copy, with in-flight restores discarded as outdated. A plain invalidation leaves the persisted data alone (the reload it triggers re-persists fresh data anyway). Two limitations: `remove` only reaches queries whose persister was registered this session, and `updateQueryData` does not persist — only actual loads do (the same limitation TanStack documents for `setQueryData`).

A failing persister never breaks the query: all persister calls are wrapped, and failures (sync or async, in any of the three functions) are reported to the console.

### Scope and docs

The option exists on `createQuery` only for now — sequential queries carry cursor and `hasMore` state, which would complicate the persisted shape. The README (options reference plus a `localStorage` example) and the interactive docs page (API reference table and type definitions) are updated, and "Persisted Queries" is removed from the *What is Omitted* section.
